### PR TITLE
Added sevral Cpp base wrappers and Java classes

### DIFF
--- a/org.openscenegraph.android/jni/Android.mk
+++ b/org.openscenegraph.android/jni/Android.mk
@@ -1,6 +1,6 @@
 LOCAL_PATH := $(call my-dir)
  
-OSG_SRC_FILES 		:= \
+OSG_SRC_FILES := \
 JNIosgViewer.cpp \
 JNIosg.cpp \
 JNIosgDB.cpp \
@@ -8,12 +8,21 @@ JNIosgUtil.cpp \
 JNIosgGA.cpp \
 JNIUtils.cpp \
 MultiViewNode.cpp \
-GLES2ShaderGenVisitor.cpp
+GLES2ShaderGenVisitor.cpp \
+screenview.cpp
 
 OSG_LDLIBS := \
 -losgdb_osg \
 -losgdb_ive \
 -losgdb_rgb \
+-losgdb_bmp \
+-losgdb_tga \
+-losgdb_stl \
+-losgdb_obj \
+-losgdb_dxf \
+-losgdb_curl \
+-losgdb_gif \
+-losgdb_jpeg \
 -losgdb_openflight \
 -losgdb_serializers_osgvolume \
 -losgdb_serializers_osgtext \
@@ -57,25 +66,78 @@ OSG_LDLIBS := \
 -losgAnimation \
 -losgUtil \
 -losg \
--lOpenThreads 
+-lOpenThreads \
+-ltiff \
+-ljpeg \
+-lgif \
+-lpng \
+-lcurl \
+-lzlib
 
+#-losgdb_serializers_osgpresentation \
+
+### Static preparation
+OSG_HEAD:=/media/christian/DATA/android-osg-sdk/gles1
+OSG_SDK:=$(OSG_HEAD)/$(TARGET_ARCH_ABI)
+OSG_3RDPARTY_DIR:=obj/local/$(TARGET_ARCH_ABI)
+OSG_3RDPARTY_LIBS_DIR:=
+OSG_3RDPARTY_COMPONENTS:=jpeg gif png tiff zlib curl
+
+define add_osg_3rdparty_component
+	include $(CLEAR_VARS)
+	LOCAL_MODULE:=$1
+	ifeq ($(strip $1),gif)
+	LOCAL_SRC_FILES:=$(OSG_HEAD)/$1lib/$(OSG_3RDPARTY_DIR)/lib$1.a
+	OSG_3RDPARTY_LIBS_DIR +=$(OSG_HEAD)/$1lib/$(OSG_3RDPARTY_DIR) 
+	else
+	ifeq ($(strip $1),png)
+        LOCAL_SRC_FILES:=$(OSG_HEAD)/lib$1/$(OSG_3RDPARTY_DIR)/lib$1.a
+        OSG_3RDPARTY_LIBS_DIR +=$(OSG_HEAD)/lib$1/$(OSG_3RDPARTY_DIR) 
+	else
+	ifeq ($(strip $1),tiff)
+        LOCAL_SRC_FILES:=$(OSG_HEAD)/lib$1/$(OSG_3RDPARTY_DIR)/lib$1.a
+        OSG_3RDPARTY_LIBS_DIR +=$(OSG_HEAD)/lib$1/$(OSG_3RDPARTY_DIR) 
+	else
+	ifeq ($(strip $1),jpeg)
+        LOCAL_SRC_FILES:=$(OSG_HEAD)/lib$1/$(OSG_3RDPARTY_DIR)/lib$1.a
+        OSG_3RDPARTY_LIBS_DIR +=$(OSG_HEAD)/lib$1/$(OSG_3RDPARTY_DIR) 
+	else
+        LOCAL_SRC_FILES:=$(OSG_HEAD)/$1/$(OSG_3RDPARTY_DIR)/lib$1.a
+        OSG_3RDPARTY_LIBS_DIR +=$(OSG_HEAD)/$1/$(OSG_3RDPARTY_DIR) 
+	endif
+	endif
+	endif
+	endif
+	include $(PREBUILT_STATIC_LIBRARY)
+endef
+
+$(foreach module,$(OSG_3RDPARTY_COMPONENTS),$(eval $(call add_osg_3rdparty_component,$(module))))
+LOCAL_INCLUDE:=${LOCAL_C_INCLUDES}
 
 ### GLES1 build
 include $(CLEAR_VARS)
-OSG_SDK := <path-to-osg-gles1-sdk> #/Users/rgaitan/Projects/OSG/osg-trunk-android-static-gles1-sdk
-OSG_SDK_LIB_PATH := $(OSG_SDK)/lib
-OSG_SDK_PLUGIN_PATH := $(OSG_SDK_LIB_PATH)/osgPlugins-3.3.8
+OSG_HEAD:=/media/christian/DATA/android-osg-sdk/gles1
+OSG_SDK:=${OSG_HEAD}/$(TARGET_ARCH_ABI)
+
+define add_lib_dir
+    LOCAL_LDFLAGS += -L$1
+endef
+
 ifneq (,$(wildcard $(OSG_SDK)/include/osg/Config))
 
-    APP_MODULES       := jniosg-gles1
-    LOCAL_CFLAGS      := -Werror -fno-short-enums -fPIC
+    APP_MODULES := jniosg-gles1
+    OSG_SDK_LIB_PATH:=$(OSG_SDK)/lib
+    OSG_SDK_PLUGIN_PATH:=$(OSG_SDK_LIB_PATH)/osgPlugins-3.3.8
+    LOCAL_CFLAGS := -Werror -fno-short-enums -fPIC
     LOCAL_CPPFLAGS    := -DOSG_LIBRARY_STATIC 
     LOCAL_SRC_FILES   := $(OSG_SRC_FILES)
     LOCAL_MODULE      := libjniosg-gles1
-    LOCAL_LDLIBS      := -llog -lGLESv1_CM -ldl 
-    LOCAL_C_INCLUDES  := $(OSG_SDK)/include
-    TARGET_LDLIBS     := $(OSG_LDLIBS)
+    LOCAL_LDLIBS      := -llog -lGLESv1_CM -ldl -lm
+    LOCAL_WHOLE_STATIC_LIBRARIES+=$(OSG_3RDPARTY_COMPONENTS)
+    LOCAL_C_INCLUDES:=${LOCAL_INCLUDE} $(OSG_SDK)/include
+    TARGET_LDLIBS := $(OSG_LDLIBS)
     LOCAL_LDFLAGS := -L$(OSG_SDK_LIB_PATH) -L$(OSG_SDK_PLUGIN_PATH) 
+    $(foreach path,$(OSG_3RDPARTY_LIBS_DIR),$(eval $(call add_lib_dir,$(path))))
     include $(BUILD_SHARED_LIBRARY)
 else
     $(warning Unable to find osg/Config file in the headers, not building libjniosg-gles1 module)
@@ -83,19 +145,23 @@ endif
 
 ### GLES2 build
 include $(CLEAR_VARS)
-OSG_SDK := <path-to-osg-gles2-sdk> #/Users/rgaitan/Projects/OSG/osg-trunk-android-static-gles2-sdk
-OSG_SDK_LIB_PATH := $(OSG_SDK)/lib
-OSG_SDK_PLUGIN_PATH := $(OSG_SDK_LIB_PATH)/osgPlugins-3.3.8
-ifneq ( ,$(wildcard $(OSG_SDK)/include/osg/Config))
-    APP_MODULES       += jniosg-gles2
-    LOCAL_CFLAGS      := -Werror -fno-short-enums -fPIC
+OSG_HEAD:=/media/christian/DATA/android-osg-sdk/gles2
+OSG_SDK2:=${OSG_HEAD}/$(TARGET_ARCH_ABI)
+ifneq ( ,$(wildcard $(OSG_SDK2)/include/osg/Config))
+
+    APP_MODULES := jniosg-gles2
+    OSG_SDK2_LIB_PATH:=$(OSG_SDK2)/lib
+    OSG_SDK2_PLUGIN_PATH:=$(OSG_SDK2_LIB_PATH)/osgPlugins-3.3.8
+    LOCAL_CFLAGS := -Werror -fno-short-enums -fPIC
     LOCAL_CPPFLAGS    := -DOSG_LIBRARY_STATIC 
     LOCAL_SRC_FILES   := $(OSG_SRC_FILES)
     LOCAL_MODULE      := libjniosg-gles2
-    LOCAL_LDLIBS      := -llog -lGLESv2 -ldl
-    LOCAL_C_INCLUDES  := $(OSG_SDK)/include
-    TARGET_LDLIBS     := $(OSG_LDLIBS)
-    LOCAL_LDFLAGS     := -L$(OSG_SDK_LIB_PATH) -L$(OSG_SDK_PLUGIN_PATH) 
+    LOCAL_LDLIBS      := -llog -lGLESv2 -ldl -lm
+    LOCAL_WHOLE_STATIC_LIBRARIES+=$(OSG_3RDPARTY_COMPONENTS)
+    LOCAL_C_INCLUDES:=${LOCAL_INCLUDE} $(OSG_SDK2)/include
+    TARGET_LDLIBS := $(OSG_LDLIBS)
+    LOCAL_LDFLAGS  := -L$(OSG_SDK2_LIB_PATH) -L$(OSG_SDK2_PLUGIN_PATH)
+    $(foreach path,$(OSG_3RDPARTY_LIBS_DIR),$(eval $(call add_lib_dir,$(path))))
     include $(BUILD_SHARED_LIBRARY)
 else
     $(warning Unable to find osg/Config file in the headers, not building libjniosg-gles2 module)

--- a/org.openscenegraph.android/jni/Android.mk
+++ b/org.openscenegraph.android/jni/Android.mk
@@ -77,7 +77,9 @@ OSG_LDLIBS := \
 #-losgdb_serializers_osgpresentation \
 
 ### Static preparation
-OSG_HEAD:=/media/christian/DATA/android-osg-sdk/gles1
+OSG_HEAD:=<path-to-osg-gles1-sdk> 
+#/Users/rgaitan/Projects/OSG/osg-trunk-android-static-gles1-sdk 
+#/media/christian/DATA/android-osg-sdk/gles1
 OSG_SDK:=$(OSG_HEAD)/$(TARGET_ARCH_ABI)
 OSG_3RDPARTY_DIR:=obj/local/$(TARGET_ARCH_ABI)
 OSG_3RDPARTY_LIBS_DIR:=
@@ -116,7 +118,9 @@ LOCAL_INCLUDE:=${LOCAL_C_INCLUDES}
 
 ### GLES1 build
 include $(CLEAR_VARS)
-OSG_HEAD:=/media/christian/DATA/android-osg-sdk/gles1
+OSG_HEAD:=<path-to-osg-gles1-sdk>
+#/Users/rgaitan/Projects/OSG/osg-trunk-android-static-gles1-sdk
+#/media/christian/DATA/android-osg-sdk/gles1
 OSG_SDK:=${OSG_HEAD}/$(TARGET_ARCH_ABI)
 
 define add_lib_dir
@@ -145,7 +149,9 @@ endif
 
 ### GLES2 build
 include $(CLEAR_VARS)
-OSG_HEAD:=/media/christian/DATA/android-osg-sdk/gles2
+OSG_HEAD:=<path-to-osg-gles1-sdk>
+#/Users/rgaitan/Projects/OSG/osg-trunk-android-static-gles2-sdk
+#/media/christian/DATA/android-osg-sdk/gles2
 OSG_SDK2:=${OSG_HEAD}/$(TARGET_ARCH_ABI)
 ifneq ( ,$(wildcard $(OSG_SDK2)/include/osg/Config))
 

--- a/org.openscenegraph.android/jni/Application.mk
+++ b/org.openscenegraph.android/jni/Application.mk
@@ -1,12 +1,14 @@
 #ANDROID APPLICATION MAKEFILE
 APP_BUILD_SCRIPT := $(call my-dir)/Android.mk
+NDK_MODULE_PATH := $(call my-dir)
 #APP_PROJECT_PATH := $(call my-dir)
 
 APP_OPTIM := release
 
-APP_PLATFORM 	:= android-8
+APP_PLATFORM 	:= android-15
+APP_CFLAGS += -fexceptions
 APP_STL 	:= gnustl_shared
 APP_CPPFLAGS 	:= -fexceptions -frtti
-APP_ABI 	:= armeabi
-APP_MODULES     := jniosg-gles1 jniosg-gles2
+APP_ABI 	:= armeabi armeabi-v7a
+#APP_MODULES     := jniosg-gles1 jniosg-gles2
 NDK_TOOLCHAIN_VERSION := 4.9

--- a/org.openscenegraph.android/jni/JNIUtils.h
+++ b/org.openscenegraph.android/jni/JNIUtils.h
@@ -1,6 +1,6 @@
 /* @License
  -------------------------------------------------------------------------------
- | osgAndroid - Copyright (C) 2012 Rafael Gait‡n, Mirage Technologies S.L.     |
+ | osgAndroid - Copyright (C) 2012 Rafael Gaitï¿½n, Mirage Technologies S.L.     |
  |                                                                             |
  | This library is free software; you can redistribute it and/or modify        |
  | it under the terms of the GNU Lesser General Public License as published    |
@@ -22,12 +22,13 @@
 #include <string>
 
 #include <osg/Referenced>
+#include <osg/Vec2>
 #include <osg/Vec3>
 #include <osg/Vec4>
 #include <osg/Quat>
+#include <osg/Image>
 
 extern std::string jstring2string(JNIEnv *env, jstring jstr);
-
 
 template<class T>
 class ReferencedType: public T, public osg::Referenced
@@ -37,6 +38,51 @@ public:
 protected:
 	~ReferencedType() { }
 };
+typedef ReferencedType<osg::Vec2> RefVec2;
 typedef ReferencedType<osg::Vec3> RefVec3;
 typedef ReferencedType<osg::Vec4> RefVec4;
 typedef ReferencedType<osg::Quat> RefQuat;
+
+inline osg::Vec4 Interpolate(osg::Vec2 _texcoord, osg::Image* _img)
+{
+	osg::Vec4 kernel[3][3];
+	int l_k, l_l;
+	float width = _img->s(), height = _img->t();
+	float xc = _texcoord.x()*(width-1); float yc = (1.0-_texcoord.y())*(height-1);
+	int xd = int(floor(xc)); int yd = int(floor(yc));
+
+	//collect values
+	for(int k = (xd-1); k < (xd+2); k++)
+	{
+		for(int l = (yd-1); l < (yd+2); l++)
+		{
+			l_k = k - (xd-1); l_l = l - (yd-1);
+			if((k<0)||(k>int(width-1))||(l<0)||(l>int(height-1)))
+			{
+				kernel[l_k][l_l] = osg::Vec4(0,0,0,0);
+			}
+			else
+			{
+				kernel[l_k][l_l] = _img->getColor(k,l,0);
+			}
+		}
+	}
+
+	float final_colour_r=0, final_colour_g=0, final_colour_b=0, final_colour_a = 0;
+	float x_offset, y_offset;
+	x_offset = (xc - (float)xd) - 0.5;
+	y_offset = (yc - (float)yd) - 0.5;
+	double dist = 0.0;
+	for(int k = 0; k < 3; k++)
+	{
+		for(int l = 0; l < 3; l++)
+		{
+			dist = (sqrt((abs((k-1)+x_offset) * abs((k-1)+x_offset)) + (abs((l-1)+y_offset) * abs((l-1)+y_offset))))/2.121320344;
+			final_colour_r += (1-dist) * kernel[k][l].x();
+			final_colour_g += (1-dist) * kernel[k][l].y();
+			final_colour_b += (1-dist) * kernel[k][l].z();
+			final_colour_a += (1-dist) * kernel[k][l].w();
+		}
+	}
+	return osg::Vec4(final_colour_r/9.0, final_colour_g/9.0, final_colour_b/9.0, final_colour_a/9.0);
+}

--- a/org.openscenegraph.android/jni/JNIosg.cpp
+++ b/org.openscenegraph.android/jni/JNIosg.cpp
@@ -23,15 +23,22 @@
 #include "JNIUtils.h"
 
 #include <osg/Node>
+#include <osg/Point>
 #include <osg/Group>
 #include <osg/MatrixTransform>
 #include <osg/Camera>
+#include <osg/Vec2>
 #include <osg/Vec3>
 #include <osg/Vec4>
 #include <osg/Matrixf>
 #include <osg/AnimationPath>
 #include <osg/io_utils>
 #include <osg/Texture2D>
+#include <osg/PrimitiveSet>
+#include <osg/Geometry>
+#include <osg/Geode>
+#include <osg/Array>
+#include <osg/LineWidth>
 
 #define  LOG_TAG    "org.openscenegraph.osg.db.JNIOSGCore"
 #define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO,LOG_TAG,__VA_ARGS__)
@@ -40,13 +47,16 @@
 extern "C"
 {
 
+
+
 /**
  * osg::Node
  */
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeDispose(JNIEnv *, jclass, jlong cptr)
 {
 	osg::Node *node = reinterpret_cast<osg::Node *>(cptr);
-	if(node != 0)
+	//if(node!=0)
+	if((node != 0) && (node->referenceCount()<2))
 		node->unref();
 }
 
@@ -82,6 +92,16 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetTexture2D(
 	}
 }
 
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetTexture(JNIEnv*, jclass, jlong cptr, jlong texture_cptr, jint tex_unit)
+{
+	osg::Node *node = reinterpret_cast<osg::Node *>(cptr);
+	osg::Texture *texture = reinterpret_cast<osg::Texture*>(texture_cptr);
+	if( node!=NULL && texture!=NULL)
+	{
+		node->getOrCreateStateSet()->setTextureAttribute((int)tex_unit, texture, osg::StateAttribute::ON | osg::StateAttribute::OVERRIDE);
+	}
+}
+
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetMode(JNIEnv *env, jclass, jlong cptr,
 		jint mode, jint value)
 {
@@ -93,6 +113,24 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetMode(JNIEn
 	}
 }
 
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetPointSize(JNIEnv* env, jclass, jlong cptr, jfloat pt_size)
+{
+	osg::Node* node = reinterpret_cast<osg::Node*>(cptr);
+	osg::Point* point = new osg::Point();
+	point->setSize((float)pt_size);
+	if(node != NULL)
+		node->getOrCreateStateSet()->setAttributeAndModes(point, osg::StateAttribute::ON);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetLineWidth(JNIEnv* env, jclass, jlong cptr, jfloat line_size)
+{
+	osg::Node* node = reinterpret_cast<osg::Node*>(cptr);
+	osg::LineWidth* lw = new osg::LineWidth();
+	lw->setWidth((float)line_size);
+	if(node != NULL)
+		node->getOrCreateStateSet()->setAttributeAndModes(lw, osg::StateAttribute::ON);
+}
+
 
 /**
  * osg::Group
@@ -100,7 +138,8 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Node_nativeSetMode(JNIEn
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Group_nativeDispose(JNIEnv *, jclass, jlong cptr)
 {
     osg::Group *g = reinterpret_cast<osg::Group *>(cptr);
-    if(g != 0)
+    //if(g!=0)
+    if((g != 0) && (g->referenceCount()<2))
         g->unref();
 }
 
@@ -137,6 +176,1076 @@ JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Group_nativeGetNumChildr
     if(g != 0)
         return g->getNumChildren();
     return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Group_nativeGetChild(JNIEnv* env, jclass, jlong cptr, jint i)
+{
+    osg::Group *g = reinterpret_cast<osg::Group *>(cptr);
+    if(g != 0)
+    {
+    	osg::Node* node = g->getChild((unsigned int)i);
+        return reinterpret_cast<jlong>(node);
+    }
+    return 0l;
+}
+
+/*
+ * osg::Geode
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geode_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	osg::Geode *g = reinterpret_cast<osg::Geode *>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geode_nativeCreateGeode(JNIEnv *, jclass)
+{
+    osg::Geode *g = new osg::Geode();
+    g->ref();
+    return reinterpret_cast<jlong>(g);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geode_nativeAddDrawable(JNIEnv *, jclass, jlong cptr, jlong cptr_drawable)
+{
+	bool result = false;
+	osg::Geode *g = reinterpret_cast<osg::Geode*>(cptr);
+	osg::Drawable* n = reinterpret_cast<osg::Drawable*>(cptr_drawable);
+	if(g!=NULL)
+	{
+		result = g->addDrawable(n);
+	}
+	return result?JNI_TRUE:JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geode_nativeRemoveDrawable(JNIEnv* env, jclass, jlong cptr, jlong cptr_drawable)
+{
+	bool result = false;
+	osg::Geode* g = reinterpret_cast<osg::Geode*>(cptr);
+	osg::Drawable* d = reinterpret_cast<osg::Drawable*>(cptr_drawable);
+	if(g!=NULL)
+	{
+		result = g->removeDrawable(d);
+	}
+	return result?JNI_TRUE:JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geode_nativeRemoveDrawables(JNIEnv* env, jclass, jlong cptr, jint i, jint m)
+{
+	bool result = false;
+	osg::Geode* g = reinterpret_cast<osg::Geode*>(cptr);
+	if(g!=NULL)
+	{
+		result = g->removeDrawables((unsigned int)i, (unsigned int)m);
+	}
+	return result?JNI_TRUE:JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geode_nativeReplaceDrawable(JNIEnv* env, jclass, jlong cptr, jlong cptr_drawable_old, jlong cptr_drawable_new)
+{
+	bool result = false;
+	osg::Geode* g = reinterpret_cast<osg::Geode*>(cptr);
+	osg::Drawable* d_old = reinterpret_cast<osg::Drawable*>(cptr_drawable_old);
+	osg::Drawable* d_new = reinterpret_cast<osg::Drawable*>(cptr_drawable_new);
+	if(g!=NULL)
+	{
+		result = g->replaceDrawable(d_old,d_new);
+	}
+	return result?JNI_TRUE:JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geode_nativeSetDrawable(JNIEnv* env, jclass, jlong cptr, jint i, jlong cptr_drawable)
+{
+	bool result = false;
+	osg::Geode* g = reinterpret_cast<osg::Geode*>(cptr);
+	osg::Drawable* d = reinterpret_cast<osg::Drawable*>(cptr_drawable);
+	if(g!=NULL)
+	{
+		result = g->setDrawable((unsigned int)i, d);
+	}
+	return result?JNI_TRUE:JNI_FALSE;
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Geode_nativeGetNumDrawables(JNIEnv* env, jclass, jlong cptr)
+{
+	int result = 0;
+	osg::Geode* g = reinterpret_cast<osg::Geode*>(cptr);
+	if(g!=NULL)
+	{
+		result = g->getNumDrawables();
+	}
+	return reinterpret_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geode_nativeGetDrawable(JNIEnv* env, jclass, jlong cptr, jint i)
+{
+	jlong result = 0;
+	osg::Geode* g = reinterpret_cast<osg::Geode*>(cptr);
+	if(g!=NULL)
+	{
+		osg::Drawable* d = g->getDrawable((int)i);
+		result = reinterpret_cast<jlong>(d);
+	}
+	return result;
+}
+
+/*
+ * osg::Geometry
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry *>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeCreateGeometry(JNIEnv *, jclass)
+{
+    osg::Geometry *g = new osg::Geometry();
+    g->ref();
+    return reinterpret_cast<jlong>(g);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetVertexArray(JNIEnv* env, jclass, jlong cptr, jobjectArray inputBuffer)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+
+	int array_n = env->GetArrayLength(inputBuffer);
+	//printf("Array size: %i\n", array_n);
+	osg::Vec3Array* _array = new osg::Vec3Array();
+
+	jobject objArray;
+	jsize subarray_n;
+	float* data;
+	for(int i = 0; i < array_n; i++)
+	{
+		objArray = env->GetObjectArrayElement(inputBuffer,i);
+		jfloatArray* cdata = reinterpret_cast<jfloatArray*>(&objArray);
+		subarray_n = env->GetArrayLength(*cdata);
+		if( subarray_n>2 )
+		{
+			data = env->GetFloatArrayElements(*cdata, 0);
+			_array->push_back(osg::Vec3(data[0] , data[1], data[2]));
+			env->ReleaseFloatArrayElements(*cdata, data, 0);
+		}
+	}
+
+	if(g!=NULL)
+	{
+		g->setVertexArray(_array);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetVertexArrayNative(JNIEnv* env, jclass, jlong cptr, jlong array_cptr)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(array_cptr);
+
+	if( (g!=NULL) && (a!=NULL) )
+	{
+		g->setVertexArray(a);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeGetVertexArray(JNIEnv* env, jclass, jlong cptr)
+{
+	jlong result = 0;
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	if(g!=NULL)
+	{
+		osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(g->getVertexArray());
+		result = reinterpret_cast<jlong>(a);
+	}
+	return result;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetNormalArray(JNIEnv* env, jclass, jlong cptr, jobjectArray inputBuffer)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+
+	int array_n = env->GetArrayLength(inputBuffer);
+	osg::Vec3Array* _array = new osg::Vec3Array();
+
+	jobject objArray;
+	jsize subarray_n;
+	float* data;
+	for(int i = 0; i < array_n; i++)
+	{
+		objArray = env->GetObjectArrayElement(inputBuffer,i);
+		jfloatArray* cdata = reinterpret_cast<jfloatArray*>(&objArray);
+		subarray_n = env->GetArrayLength(*cdata);
+		if( subarray_n>2 )
+		{
+			data = env->GetFloatArrayElements(*cdata, 0);
+			_array->push_back(osg::Vec3(data[0] , data[1], data[2]));
+			env->ReleaseFloatArrayElements(*cdata, data, 0);
+		}
+	}
+
+	if(g!=NULL)
+	{
+		g->setNormalArray(_array);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetNormalArrayNative(JNIEnv* env, jclass, jlong cptr, jlong array_cptr)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(array_cptr);
+
+	if( (g!=NULL) && (a!=NULL) )
+	{
+		g->setNormalArray(a);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeGetNormalArray(JNIEnv* env, jclass, jlong cptr)
+{
+	jlong result = 0;
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	if(g!=NULL)
+	{
+		osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(g->getNormalArray());
+		result = reinterpret_cast<jlong>(a);
+	}
+	return result;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetColorArray(JNIEnv* env, jclass, jlong cptr, jobjectArray inputBuffer)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+
+	int array_n = env->GetArrayLength(inputBuffer);
+
+	//LOGI("Colour Array size: %i\n", array_n);
+	osg::Vec4Array* _array = new osg::Vec4Array();
+
+	jobject objArray;
+	jsize subarray_n;
+	float* data;
+	for(int i = 0; i < array_n; i++)
+	{
+		objArray = env->GetObjectArrayElement(inputBuffer,i);
+		jfloatArray* cdata = reinterpret_cast<jfloatArray*>(&objArray);
+		subarray_n = env->GetArrayLength(*cdata);
+		//LOGI("subarray size at %i: %i\n", i, subarray_n);
+		if( subarray_n>3 )
+		{
+			data = env->GetFloatArrayElements(*cdata, 0);
+			_array->push_back(osg::Vec4(data[0], data[1], data[2], data[3]));
+			env->ReleaseFloatArrayElements(*cdata, data, 0);
+		}
+	}
+
+	if(g!=NULL)
+	{
+		g->setColorArray(_array);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetColorArrayNative(JNIEnv* env, jclass, jlong cptr, jlong array_cptr)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(array_cptr);
+
+	if( (g!=NULL) && (a!=NULL) )
+	{
+		g->setColorArray(a);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeGetColorArray(JNIEnv* env, jclass, jlong cptr)
+{
+	jlong result = 0;
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	if(g!=NULL)
+	{
+		osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(g->getColorArray());
+		result = reinterpret_cast<jlong>(a);
+	}
+	return result;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetTexCoordArray(JNIEnv* env, jclass, jlong cptr, jobjectArray inputBuffer, jint tex_unit)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+
+	int array_n = env->GetArrayLength(inputBuffer);
+	osg::Vec2Array* _array = new osg::Vec2Array();
+
+	jobject objArray;
+	jsize subarray_n;
+	float* data;
+	for(int i = 0; i < array_n; i++)
+	{
+		objArray = env->GetObjectArrayElement(inputBuffer,i);
+		jfloatArray* cdata = reinterpret_cast<jfloatArray*>(&objArray);
+		subarray_n = env->GetArrayLength(*cdata);
+		if( subarray_n>1 )
+		{
+			data = env->GetFloatArrayElements(*cdata, 0);
+			_array->push_back(osg::Vec2(data[0], data[1]));
+			env->ReleaseFloatArrayElements(*cdata, data, 0);
+		}
+	}
+
+	if(g!=NULL)
+	{
+		g->setTexCoordArray((int)tex_unit,_array);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetTexCoordArrayNative(JNIEnv* env, jclass, jlong cptr, jlong array_cptr, jint tex_unit)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(array_cptr);
+
+	if( (g!=NULL) && (a!=NULL) )
+	{
+		g->setTexCoordArray((int)tex_unit,a);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeGetTexCoordArray(JNIEnv* env, jclass, jlong cptr, jint tex_unit)
+{
+	jlong result = 0;
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	if(g!=NULL)
+	{
+		osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(g->getTexCoordArray((int)tex_unit));
+		result = reinterpret_cast<jlong>(a);
+	}
+	return result;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetNormalBinding(JNIEnv *, jclass, jlong cptr, jbyte binding)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	g->setNormalBinding(osg::Geometry::AttributeBinding(binding));
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetColorBinding(JNIEnv *, jclass, jlong cptr, jbyte binding)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	g->setColorBinding(osg::Geometry::AttributeBinding(binding));
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeAddPrimitiveSet(JNIEnv *, jclass, jlong cptr, jlong set_cptr)
+{
+	osg::Geometry *g = reinterpret_cast<osg::Geometry*>(cptr);
+	osg::PrimitiveSet *n = reinterpret_cast<osg::PrimitiveSet*>(set_cptr);
+	if(g!=NULL)
+	{
+        return g->addPrimitiveSet(n)?JNI_TRUE:JNI_FALSE;
+	}
+	return JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeSetPrimitiveSetList(JNIEnv* env, jclass, jlong cptr, jlong list_cptr)
+{
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	osg::Geometry::PrimitiveSetList* n = reinterpret_cast<osg::Geometry::PrimitiveSetList*>(list_cptr);
+	if(g!=NULL)
+	{
+		g->setPrimitiveSetList(*n);
+	}
+}
+
+// Parameter explanation:
+// cptr: this (Geometry*)
+// i: array index
+// Cg: Projection Center (global coords) - Vec3
+// rotmat: 3x3 Rotation Matrixf
+// R: Camera surface parameters (in metres)
+// img: osg::Image* to be sampled
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeTextureFromPosePoint(JNIEnv* env, jclass, jlong cptr, jint i, jlong Cg_ptr, jlong trmat_ptr, jlong R_ptr, jlong img_ptr)
+{
+	bool use_texcoord = false;
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	if(g==NULL)
+		return JNI_FALSE;
+	osg::Vec3Array* varray = (osg::Vec3Array*)(g->getVertexArray());
+	if(varray==NULL)
+		return JNI_FALSE;
+	if((unsigned int)(i) > (varray->getNumElements()-1))
+		return JNI_FALSE;
+	osg::Vec4Array* carray = (osg::Vec4Array*)(g->getColorArray());
+	if(carray==NULL)
+	{
+		carray = new osg::Vec4Array();
+		carray->ref();
+	}
+	if(carray->getNumElements() < varray->getNumElements())
+	{
+		carray->resizeArray(varray->getNumElements());
+	}
+	osg::Vec2Array* tarray = (osg::Vec2Array*)(g->getTexCoordArray(0));
+	if(tarray!=NULL)
+	{
+		use_texcoord = true;
+		if(tarray->getNumElements() < varray->getNumElements())
+		{
+			tarray->resizeArray(varray->getNumElements());
+		}
+	}
+
+	osg::Image* img = reinterpret_cast<osg::Image *>(img_ptr);
+	if(img==NULL)
+		return JNI_FALSE;
+
+	RefVec3* Cg = reinterpret_cast<RefVec3 *>(Cg_ptr);
+	RefVec3* R = reinterpret_cast<RefVec3 *>(R_ptr);
+	osg::RefMatrixf* trmat = reinterpret_cast<osg::RefMatrixf* >(trmat_ptr);
+	//osg::Matrix3 rotmat; rotmat.set((*trmat)(0,0), (*trmat)(0,1), (*trmat)(0,2), (*trmat)(1,0), (*trmat)(1,1), (*trmat)(1,2), (*trmat)(2,0), (*trmat)(2,1), (*trmat)(2,2));
+	osg::Matrixf rotmat; rotmat.set((*trmat)(0,0), (*trmat)(0,1), (*trmat)(0,2), 0, (*trmat)(1,0), (*trmat)(1,1), (*trmat)(1,2), 0, (*trmat)(2,0), (*trmat)(2,1), (*trmat)(2,2), 0, 0, 0, 0, 1);
+
+	osg::Vec3 M = varray->at((unsigned int)i);
+	osg::Vec3 D = rotmat * M;
+	//osg::Vec3 D = M*rotmat;
+	if(D.z()>0)
+	{
+		float u = ((R->z()*(D.x()/D.z()))+(R->x()/2.0f))/R->x();
+		float v = ((R->z()*(D.y()/D.z()))+(R->y()/2.0f))/R->y();
+		if( (u>0) && (u<1) && (v>0) && (v<1) )
+		{
+			osg::Vec2 tex_coord(u,v);
+			if(use_texcoord)
+			{
+				tarray->at((unsigned int)i) = tex_coord;
+			}
+			osg::Vec4 _color = Interpolate(tex_coord, img);
+			carray->at((unsigned int)i) = _color;
+			return JNI_TRUE;
+		}
+	}
+	return JNI_FALSE;
+}
+
+// Parameter explanation:
+// cptr: this (Geometry*)
+// i: array index
+// Cg: Projection Center (global coords) - Vec3
+// rotmat: 3x3 Rotation Matrixf
+// R: Camera surface parameters (in metres)
+// img: osg::Image* to be sampled
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Geometry_nativeTextureFromPose(JNIEnv* env, jclass, jlong cptr, jlong Cg_ptr, jlong trmat_ptr, jlong R_ptr, jlong img_ptr)
+{
+	int colored_point = 0;
+	bool use_texcoord = false;
+	osg::Geometry* g = reinterpret_cast<osg::Geometry*>(cptr);
+	if(g==NULL)
+		return 0;
+	osg::Vec3Array* varray = (osg::Vec3Array*)(g->getVertexArray());
+	if(varray==NULL)
+		return 0;
+
+	osg::Vec4Array* carray = (osg::Vec4Array*)(g->getColorArray());
+	if(carray==NULL)
+	{
+		carray = new osg::Vec4Array();
+		carray->ref();
+	}
+	if(carray->getNumElements() < varray->getNumElements())
+	{
+		carray->resizeArray(varray->getNumElements());
+	}
+	osg::Vec2Array* tarray = (osg::Vec2Array*)(g->getTexCoordArray(0));
+	if(tarray!=NULL)
+	{
+		use_texcoord = true;
+		if(tarray->getNumElements() < varray->getNumElements())
+		{
+			tarray->resizeArray(varray->getNumElements());
+		}
+	}
+
+	osg::Image* img = reinterpret_cast<osg::Image *>(img_ptr);
+	if(img==NULL)
+		return 0;
+
+	RefVec3* Cg = reinterpret_cast<RefVec3 *>(Cg_ptr);
+	RefVec3* R = reinterpret_cast<RefVec3 *>(R_ptr);
+	osg::RefMatrixf* trmat = reinterpret_cast<osg::RefMatrixf* >(trmat_ptr);
+	osg::Matrixf rotmat; rotmat.set((*trmat)(0,0), (*trmat)(0,1), (*trmat)(0,2), 0, (*trmat)(1,0), (*trmat)(1,1), (*trmat)(1,2), 0, (*trmat)(2,0), (*trmat)(2,1), (*trmat)(2,2), 0, 0, 0, 0, 1);
+
+	osg::Vec3 M, D;
+	for(unsigned int i = 0; i < varray->getNumElements(); i++)
+	{
+		M = varray->at(i);
+		D = rotmat * M;
+		//D = M*rotmat;
+		if(D.z()>0)
+		{
+			float u = ((R->z()*(D.x()/D.z()))+(R->x()/2.0f))/R->x();
+			float v = ((R->z()*(D.y()/D.z()))+(R->y()/2.0f))/R->y();
+			if( (u>0) && (u<1) && (v>0) && (v<1) )
+			{
+				osg::Vec2 tex_coord(u,v);
+				if(use_texcoord)
+				{
+					tarray->at((unsigned int)i) = tex_coord;
+				}
+				osg::Vec4 _color = Interpolate(tex_coord, img);
+				carray->at((unsigned int)i) = _color;
+				//return JNI_TRUE;
+				colored_point++;
+			}
+		}
+	}
+
+	return (jint)colored_point;
+}
+
+/*
+ * osg::Drawable
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Drawable_nativeDispose(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Drawable* g = reinterpret_cast<osg::Drawable*>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Drawable_nativeAsDrawable(JNIEnv *, jclass, jlong cptr)
+{
+	osg::Drawable *g = reinterpret_cast<osg::Drawable *>(cptr);
+	return reinterpret_cast<jlong>(g);
+}
+
+/*
+ * osg::PrimitiveSet
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_PrimitiveSet_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	osg::PrimitiveSet *g = reinterpret_cast<osg::PrimitiveSet *>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+/*
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_PrimitiveSet_nativeCreatePrimitiveSet(JNIEnv *, jclass, jint type, jint mode)
+{
+	osg::PrimitiveSet *g = NULL;
+	switch(type)
+	{
+	case 0:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::PrimitiveType, (int)mode);
+		break;
+	}
+	case 1:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::DrawArraysPrimitiveType, (int)mode);
+		break;
+	}
+	case 2:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::DrawArrayLengthsPrimitiveType, (int)mode);
+		break;
+	}
+	case 3:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::DrawElementsUBytePrimitiveType, (int)mode);
+		break;
+	}
+	case 4:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::DrawElementsUShortPrimitiveType, (int)mode);
+		break;
+	}
+	case 5:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::DrawElementsUIntPrimitiveType, (int)mode);
+		break;
+	}
+	default:
+	{
+		g = new osg::PrimitiveSet(osg::PrimitiveSet::PrimitiveType, (int)mode);
+		break;
+	}
+	}
+
+	if(g!=NULL)
+		g->ref();
+    return reinterpret_cast<jlong>(g);
+}
+*/
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_PrimitiveSet_nativeAsPrimitiveSet(JNIEnv *, jclass, jlong cptr)
+{
+	osg::PrimitiveSet *g = reinterpret_cast<osg::PrimitiveSet *>(cptr);
+	return reinterpret_cast<jlong>(g);
+}
+
+/*
+ * osg::PrimitiveSetList
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_PrimitiveSetList_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	osg::Geometry::PrimitiveSetList* g = reinterpret_cast<osg::Geometry::PrimitiveSetList*>(cptr);
+	//if(g!=NULL)
+	//	g->unref();
+}
+
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_PrimitiveSetList_nativeCreatePrimitiveSetList(JNIEnv* env, jclass)
+{
+	osg::Geometry::PrimitiveSetList* l = new osg::Geometry::PrimitiveSetList();
+	//l->ref();
+	return reinterpret_cast<jlong>(l);
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_PrimitiveSetList_nativeSize(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Geometry::PrimitiveSetList* g = reinterpret_cast<osg::Geometry::PrimitiveSetList*>(cptr);
+	if(g!=NULL)
+		return (jint)(g->size());
+	return 0;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_PrimitiveSetList_nativePushBackPrimitiveSet(JNIEnv* env, jclass, jlong cptr, jlong object_cptr)
+{
+	osg::Geometry::PrimitiveSetList* l = reinterpret_cast<osg::Geometry::PrimitiveSetList*>(cptr);
+	osg::PrimitiveSet* obj = reinterpret_cast<osg::PrimitiveSet*>(object_cptr);
+	if((l!=NULL)&&(obj!=NULL))
+	{
+		l->push_back(obj);
+	}
+}
+
+/*
+ * osg::DrawArrays
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_DrawArrays_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	osg::DrawArrays *g = reinterpret_cast<osg::DrawArrays *>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_DrawArrays_nativeCreateDrawArrays(JNIEnv *, jclass, jint mode, jint first, jint count)
+{
+	osg::DrawArrays *g = new osg::DrawArrays((int)mode, first, count);
+	g->ref();
+	return reinterpret_cast<jlong>(g);
+}
+
+/*
+ * osg::DrawElementsUInt
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_DrawElementsUInt_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	osg::DrawElementsUInt *g = reinterpret_cast<osg::DrawElementsUInt *>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_DrawElementsUInt_nativeCreateDrawElementsUInt(JNIEnv* env, jclass, jint mode, jint count)
+{
+	osg::DrawElementsUInt *g = new osg::DrawElementsUInt((int)mode, count);
+	g->ref();
+	return reinterpret_cast<jlong>(g);
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_DrawElementsUInt_nativeSize(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::DrawElementsUInt* g = reinterpret_cast<osg::DrawElementsUInt*>(cptr);
+	if(g!=NULL)
+		return (jint)(g->getNumIndices());
+	return 0;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_DrawElementsUInt_nativePushBackUInt(JNIEnv* env, jclass, jlong cptr, jint value)
+{
+	osg::DrawElementsUInt* l = reinterpret_cast<osg::DrawElementsUInt*>(cptr);
+	if((l!=NULL))
+	{
+		l->push_back(value);
+	}
+}
+
+/*
+ * osg::Texture
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Texture_nativeDispose(JNIEnv*, jclass, jlong cptr)
+{
+	osg::Texture* t = reinterpret_cast<osg::Texture*>(cptr);
+	if(t!=NULL)
+		t->unref();
+}
+
+//JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Texture_nativeCreateTexture(JNIEnv*, jclass)
+//{
+//	osg::Texture* t = new osg::Texture();
+//	t->ref();
+//	return reinterpret_cast<jlong>(t);
+//}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Texture_nativeSetImage(JNIEnv*, jclass, jlong cptr, jint face, jlong image_cptr)
+{
+	osg::Texture2D* t = reinterpret_cast<osg::Texture2D*>(cptr);
+	osg::Image* i = reinterpret_cast<osg::Image*>(image_cptr);
+	if((t!=NULL)&&(i!=NULL))
+		t->setImage((int)face, i);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Texture_nativeGetImage(JNIEnv*, jclass, jlong cptr, jint face)
+{
+	jlong result = 0;
+	osg::Texture2D* t = reinterpret_cast<osg::Texture2D*>(cptr);
+	if(t!=NULL)
+	{
+		osg::Image* i = t->getImage((int)face);
+		result = reinterpret_cast<jlong>(i);
+	}
+	return result;
+}
+
+/*
+ * osg::Texture2D
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Texture2D_nativeDispose(JNIEnv*, jclass, jlong cptr)
+{
+	osg::Texture2D* t = reinterpret_cast<osg::Texture2D*>(cptr);
+	if(t!=NULL)
+		t->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Texture2D_nativeCreateTexture2D(JNIEnv*, jclass)
+{
+	osg::Texture2D* t = new osg::Texture2D();
+	t->ref();
+	return reinterpret_cast<jlong>(t);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Texture2D_nativeSetImage(JNIEnv*, jclass, jlong cptr, jlong image_cptr)
+{
+	osg::Texture2D* t = reinterpret_cast<osg::Texture2D*>(cptr);
+	osg::Image* i = reinterpret_cast<osg::Image*>(image_cptr);
+	if((t!=NULL)&&(i!=NULL))
+		t->setImage(i);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Texture2D_nativeGetImage(JNIEnv*, jclass, jlong cptr)
+{
+	jlong result = 0;
+	osg::Texture2D* t = reinterpret_cast<osg::Texture2D*>(cptr);
+	if(t!=NULL)
+	{
+		osg::Image* i = t->getImage();
+		result = reinterpret_cast<jlong>(i);
+	}
+	return result;
+}
+
+
+/*
+ * osg::Object
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Object_nativeDispose(JNIEnv*, jclass, jlong cptr)
+{
+	osg::Object *o = reinterpret_cast<osg::Object*>(cptr);
+	if(o!=NULL)
+		o->unref();
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Object_nativeSetDataVariance(JNIEnv*, jclass, jlong cptr, jint dv)
+{
+	osg::Object *o = reinterpret_cast<osg::Object*>(cptr);
+	if(o!=NULL)
+		o->setDataVariance(osg::Object::DataVariance(dv));
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Object_nativeGetDataVariance(JNIEnv*, jclass, jlong cptr)
+{
+	jint result = 0;
+	osg::Object *o = reinterpret_cast<osg::Object*>(cptr);
+	if(o!=NULL)
+		result = (int)(o->getDataVariance());
+	return result;
+}
+
+
+/*
+ * osg::Array
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Array_nativeDispose(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Array* g = reinterpret_cast<osg::Array*>(cptr);
+	if(g!=NULL)
+		g->unref();
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Array_nativeSize(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Array* g = reinterpret_cast<osg::Array*>(cptr);
+	if(g!=NULL)
+		return (jint)(g->getNumElements());
+	return 0;
+}
+
+/*
+ * osg::Vec2Array
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativeDispose(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(cptr);
+	if(a!=NULL)
+		a->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativeCreateVec2Array(JNIEnv *, jclass)
+{
+	osg::Vec2Array *a = new osg::Vec2Array();
+	a->ref();
+	return reinterpret_cast<jlong>(a);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativePushBackVec2(JNIEnv* env, jclass, jlong cptr, jlong vec_cptr)
+{
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(cptr);
+	RefVec2 *v = reinterpret_cast<RefVec2*>(vec_cptr);
+	//osg::Vec2* original = reinterpret_cast<osg::Vec2*>(v->ptr());
+	if(a!=NULL)
+	{
+		//a->push_back(*original);
+		a->push_back(*v);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativePushBackFloatArray(JNIEnv* env, jclass, jlong cptr, jfloatArray array_cptr)
+{
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(cptr);
+	float* data;
+	jsize size_a = env->GetArrayLength(array_cptr);
+	if( size_a == 2 )
+	{
+		data = env->GetFloatArrayElements(array_cptr, 0);
+		if(a!=NULL)
+		{
+			a->push_back(osg::Vec2(data[0], data[1]));
+		}
+		env->ReleaseFloatArrayElements(array_cptr, data, 0);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativePopBack(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(cptr);
+	if((a!=NULL) && (a->getNumElements()>0))
+	{
+		//unsigned int pos = a->getNumElements()-1;
+		osg::Vec2 v = a->back();
+		a->pop_back();
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(v.x(), v.y());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativeGet(JNIEnv* env, jclass, jlong cptr, jint i)
+{
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(cptr);
+	if((a!=NULL) && (a->getNumElements()>0))
+	{
+		osg::Vec2 v = a->at((unsigned int)i);
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(v.x(), v.y());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Vec2Array_nativeSet(JNIEnv* env, jclass, jlong cptr, jint i, jlong vec_cptr)
+{
+	osg::Vec2Array* a = reinterpret_cast<osg::Vec2Array*>(cptr);
+	RefVec2 *v = reinterpret_cast<RefVec2*>(vec_cptr);
+	osg::Vec2* original = reinterpret_cast<osg::Vec2*>(v->ptr());
+	if((a!=NULL) && (a->getNumElements()>i))
+	{
+		a->at((unsigned int)i) = *original;
+		return JNI_TRUE;
+	}
+	return JNI_FALSE;
+}
+
+/*
+ * osg::Vec3Array
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativeDispose(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(cptr);
+	if(a!=NULL)
+		a->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativeCreateVec3Array(JNIEnv *, jclass)
+{
+	osg::Vec3Array *a = new osg::Vec3Array();
+	a->ref();
+	return reinterpret_cast<jlong>(a);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativePushBackVec3(JNIEnv* env, jclass, jlong cptr, jlong vec_cptr)
+{
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(cptr);
+	RefVec3 *v = reinterpret_cast<RefVec3*>(vec_cptr);
+	//osg::Vec3* original = reinterpret_cast<osg::Vec3*>(v->ptr());
+	if(a!=NULL)
+	{
+		//a->push_back(*original);
+		a->push_back(*v);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativePushBackFloatArray(JNIEnv* env, jclass, jlong cptr, jfloatArray array_cptr)
+{
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(cptr);
+	float* data;
+	jsize size_a = env->GetArrayLength(array_cptr);
+	if( size_a == 3 )
+	{
+		data = env->GetFloatArrayElements(array_cptr, 0);
+		if(a!=NULL)
+		{
+			a->push_back(osg::Vec3(data[0], data[1], data[2]));
+		}
+		env->ReleaseFloatArrayElements(array_cptr, data, 0);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativePopBack(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(cptr);
+	if((a!=NULL) && (a->getNumElements()>0))
+	{
+		//unsigned int pos = a->getNumElements()-1;
+		osg::Vec3 v = a->back();
+		a->pop_back();
+		RefVec3 *refRes = new RefVec3();
+		refRes->set(v.x(), v.y(), v.z());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativeGet(JNIEnv* env, jclass, jlong cptr, jint i)
+{
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(cptr);
+	if((a!=NULL) && (a->getNumElements()>0))
+	{
+		osg::Vec3 v = a->at((unsigned int)i);
+		RefVec3 *refRes = new RefVec3();
+		refRes->set(v.x(), v.y(), v.z());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Vec3Array_nativeSet(JNIEnv* env, jclass, jlong cptr, jint i, jlong vec_cptr)
+{
+	osg::Vec3Array* a = reinterpret_cast<osg::Vec3Array*>(cptr);
+	RefVec3 *v = reinterpret_cast<RefVec3*>(vec_cptr);
+	osg::Vec3* original = reinterpret_cast<osg::Vec3*>(v->ptr());
+	if((a!=NULL) && (a->getNumElements()>i))
+	{
+		a->at((unsigned int)i) = *original;
+		return JNI_TRUE;
+	}
+	return JNI_FALSE;
+}
+
+/*
+ * osg::Vec4Array
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativeDispose(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(cptr);
+	if(a!=NULL)
+		a->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativeCreateVec4Array(JNIEnv *, jclass)
+{
+	osg::Vec4Array *a = new osg::Vec4Array();
+	a->ref();
+	return reinterpret_cast<jlong>(a);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativePushBackVec4(JNIEnv* env, jclass, jlong cptr, jlong vec_cptr)
+{
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(cptr);
+	RefVec4 *v = reinterpret_cast<RefVec4*>(vec_cptr);
+	//osg::Vec4* original = reinterpret_cast<osg::Vec4*>(v->ptr());
+	if(a!=NULL)
+	{
+		//a->push_back(*original);
+		a->push_back(*v);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativePushBackFloatArray(JNIEnv* env, jclass, jlong cptr, jfloatArray array_cptr)
+{
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(cptr);
+	float* data;
+	jsize size_a = env->GetArrayLength(array_cptr);
+	if( size_a == 4 )
+	{
+		data = env->GetFloatArrayElements(array_cptr, 0);
+		if(a!=NULL)
+		{
+			a->push_back(osg::Vec4(data[0], data[1], data[2], data[3]));
+		}
+		env->ReleaseFloatArrayElements(array_cptr, data, 0);
+	}
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativePopBack(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(cptr);
+	if((a!=NULL) && (a->getNumElements()>0))
+	{
+		//unsigned int pos = a->getNumElements()-1;
+		osg::Vec4 v = a->back();
+		a->pop_back();
+		RefVec4 *refRes = new RefVec4();
+		refRes->set(v.x(), v.y(), v.z(), v.a());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativeGet(JNIEnv* env, jclass, jlong cptr, jint i)
+{
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(cptr);
+	if((a!=NULL) && (a->getNumElements()>0))
+	{
+		osg::Vec4 v = a->at((unsigned int)i);
+		RefVec4 *refRes = new RefVec4();
+		refRes->set(v.x(), v.y(), v.z(), v.a());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Vec4Array_nativeSet(JNIEnv* env, jclass, jlong cptr, jint i, jlong vec_cptr)
+{
+	osg::Vec4Array* a = reinterpret_cast<osg::Vec4Array*>(cptr);
+	RefVec4 *v = reinterpret_cast<RefVec4*>(vec_cptr);
+	osg::Vec4* original = reinterpret_cast<osg::Vec4*>(v->ptr());
+	if((a!=NULL) && (a->getNumElements()>i))
+	{
+		a->at((unsigned int)i) = *original;
+		return JNI_TRUE;
+	}
+	return JNI_FALSE;
 }
 
 /**
@@ -202,6 +1311,41 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Camera_nativeSetClearCol
 	}
 }
 
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Camera_nativeSetClearColorVec(JNIEnv* env, jclass, jlong cptr, jlong vec_cptr)
+{
+	osg::Camera* g = reinterpret_cast<osg::Camera*>(cptr);
+	RefVec4* v = reinterpret_cast<RefVec4*>(vec_cptr);
+	if((g!=NULL)&&(v!=NULL))
+		g->setClearColor(*v);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Camera_nativeGetClearColorVec(JNIEnv* env, jclass, jlong cptr)
+{
+    osg::Camera *g = reinterpret_cast<osg::Camera *>(cptr);
+    if(g != 0)
+    {
+        osg::Vec4 v = g->getClearColor();
+		RefVec4 *refRes = new RefVec4();
+		refRes->set(v.x(), v.y(), v.z(), v.a());
+		refRes->ref();
+        return reinterpret_cast<jlong>(refRes);
+    }
+    return 0l;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Camera_nativeGetViewMatrix(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Camera *camera = reinterpret_cast<osg::Camera *>(cptr);
+    if(camera != 0)
+    {
+        osg::Matrix mat = camera->getViewMatrix();
+        osg::RefMatrixf *matrix = new osg::RefMatrixf(mat);
+        matrix->ref();
+        return reinterpret_cast<jlong>(matrix);
+    }
+    return 0l;
+}
+
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Camera_nativeSetViewMatrixAsLookAt(JNIEnv *, jclass, jlong cptr,
                                                                             jlong eye, jlong center, jlong up)
 {
@@ -225,6 +1369,7 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Camera_nativeSetViewMatr
         camera->setViewMatrix(*m);
     }
 }
+
 
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Camera_nativeSetProjectionMatrix(JNIEnv *, jclass, jlong cptr,
                                                                             jlong cptrmatrix)
@@ -289,6 +1434,191 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Camera_nativeSetCullRigh
         	camera->setNodeMask(0xffffffff);
         }
     }
+}
+
+/**
+ * osg::Vec2
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeDispose(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+		v->unref();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeCreateVec2(JNIEnv *, jclass)
+{
+	RefVec2 *v = new RefVec2();
+	v->ref();
+	return reinterpret_cast<jlong>(v);
+}
+
+JNIEXPORT float JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeX(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		return v->x();
+	}
+	return 0.0f;
+}
+
+JNIEXPORT float JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeY(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		return v->y();
+	}
+	return 0.0f;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeSet(JNIEnv *, jclass, jlong cptr,
+		jfloat x, jfloat y)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		v->set(x,y);
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeSetX(JNIEnv *, jclass, jlong cptr,
+		jfloat value)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		v->x() = value;
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeSetY(JNIEnv *, jclass, jlong cptr,
+		jfloat value)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		v->y() = value;
+	}
+}
+
+JNIEXPORT jfloat JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeLength(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		return v->length();
+	}
+	return 0.0f;
+}
+
+JNIEXPORT jfloat JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeLength2(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		return v->length2();
+	}
+	return 0.0f;
+}
+
+JNIEXPORT long JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeDiv(JNIEnv *, jclass, jlong cptr,
+		jfloat value)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		osg::Vec2 res = *v/value;
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(res);
+		refRes->ref();
+		return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT float JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeDotProduct(JNIEnv *, jclass, jlong cptr,
+		jlong lrhs)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	RefVec2 *rhs = reinterpret_cast<RefVec2 *>(lrhs);
+	if(v != 0 && rhs !=0)
+	{
+		return (*v)*(*rhs);
+	}
+	return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeEscalarProduct(JNIEnv *, jclass, jlong cptr,
+		jfloat value)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		osg::Vec2 res = (*v)*value;
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(res);
+		refRes->ref();
+		return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeSum(JNIEnv *, jclass, jlong cptr,
+		jlong lrhs)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	RefVec2 *rhs = reinterpret_cast<RefVec2 *>(lrhs);
+	if(v != 0 && rhs !=0)
+	{
+		osg::Vec2 res = (*v)+(*rhs);
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(res);
+		refRes->ref();
+		return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeSub(JNIEnv *, jclass, jlong cptr,
+		jlong lrhs)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	RefVec2 *rhs = reinterpret_cast<RefVec2 *>(lrhs);
+	if(v != 0 && rhs !=0)
+	{
+		osg::Vec2 res = (*v)-(*rhs);
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(res);
+		refRes->ref();
+		return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
+}
+
+JNIEXPORT jfloat JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeNormalize(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		return v->normalize();
+	}
+	return 0;
+}
+
+JNIEXPORT jfloat JNICALL Java_org_openscenegraph_osg_core_Vec2_nativeNegation(JNIEnv *, jclass, jlong cptr)
+{
+	RefVec2 *v = reinterpret_cast<RefVec2 *>(cptr);
+	if(v != 0)
+	{
+		osg::Vec2 res = -(*v);
+		RefVec2 *refRes = new RefVec2();
+		refRes->set(res);
+		refRes->ref();
+		return reinterpret_cast<jlong>(refRes);
+	}
+	return 0l;
 }
 
 /**
@@ -814,6 +2144,63 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeDispose(JNI
     }
 }
 
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeInverse(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+	osg::RefMatrixf *result = NULL;
+	if(m!=0)
+	{
+		osg::Matrixf inv = osg::Matrixf::inverse(*m);
+		result = new osg::RefMatrixf(inv);
+		result->ref();
+	}
+	return reinterpret_cast<jlong>(result);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeTranspose(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+	osg::RefMatrixf *result = NULL;
+	if(m!=0)
+	{
+		osg::Matrixf _mat = osg::Matrixf(*m);
+		float* data = (float*)(_mat.ptr());
+		//LOGI("[%f,%f,%f,%f]",data[0],data[1],data[2],data[3]);
+		//LOGI("[%f,%f,%f,%f]",data[4],data[5],data[6],data[7]);
+		//LOGI("[%f,%f,%f,%f]",data[8],data[9],data[10],data[11]);
+		//LOGI("[%f,%f,%f,%f]",data[12],data[13],data[14],data[15]);
+		osg::Matrixf* _t = new osg::Matrixf();
+		_t->set(data[0], data[4], data[8], data[12], data[1], data[5], data[9], data[13], data[2], data[6], data[10], data[14], data[3], data[7], data[11], data[15]);
+		result = new osg::RefMatrixf(*_t);
+		result->ref();
+	}
+	return reinterpret_cast<jlong>(result);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeScale(JNIEnv* env, jclass, jlong vec_cptr)
+{
+	RefVec3 *v = reinterpret_cast<RefVec3 *>(vec_cptr);
+	osg::RefMatrixf *result = NULL;
+	if(v!=0)
+	{
+		osg::Matrixf mScale = osg::Matrixf::scale(v->x(), v->y(), v->z());
+		result = new osg::RefMatrixf(mScale);
+		result->ref();
+	}
+	return reinterpret_cast<jlong>(result);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeMult(JNIEnv* env, jclass, jlong cptr, jlong m1_ptr, jlong m2_ptr)
+{
+	osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+	osg::RefMatrixf *m1 = reinterpret_cast<osg::RefMatrixf *>(m1_ptr);
+	osg::RefMatrixf *m2 = reinterpret_cast<osg::RefMatrixf *>(m2_ptr);
+	if((m!=NULL)&&(m1!=NULL)&&(m2!=NULL))
+	{
+		m->mult(*m1, *m2);
+	}
+}
+
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeSet(JNIEnv *, jclass, jlong cptr,
         jfloat a00, jfloat a01, jfloat a02, jfloat a03, jfloat a10, jfloat a11, jfloat a12, jfloat a13,
         jfloat a20, jfloat a21, jfloat a22, jfloat a23, jfloat a30, jfloat a31, jfloat a32, jfloat a33)
@@ -825,6 +2212,49 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeSet(JNIEnv 
                 a23, a30, a31, a32, a33);
         //osg::notify(osg::NOTICE) << "Matrix:" << *m << std::endl;
     }
+}
+
+JNIEXPORT jfloat JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeGet(JNIEnv* env, jclass, jlong cptr, jint row, jint column)
+{
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+    if(m != 0)
+    {
+    	float* data = (float*)(m->ptr());
+    	return data[row*4+column];
+    }
+    return 0.f;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeGetTranslation(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+	osg::RefMatrixf *result = NULL;
+	if(m!=0)
+	{
+		osg::Matrixf _mat = osg::Matrixf(*m);
+		float* data = (float*)(_mat.ptr());
+		osg::Matrixf* _t = new osg::Matrixf();
+		_t->set(1, 0, 0, data[3], 0, 1, 0, data[7], 0, 0, 1, data[11], data[12], data[13], data[14], data[15]);
+		result = new osg::RefMatrixf(*_t);
+		result->ref();
+	}
+	return reinterpret_cast<jlong>(result);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeGetRotation(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+	osg::RefMatrixf *result = NULL;
+	if(m!=0)
+	{
+		osg::Matrixf _mat = osg::Matrixf(*m);
+		float* data = (float*)(_mat.ptr());
+		osg::Matrixf* _t = new osg::Matrixf();
+		_t->set(data[0], data[1], data[2], 0, data[4], data[5], data[6], 0, data[8], data[9], data[10], 0, 0, 0, 0, 1);
+		result = new osg::RefMatrixf(*_t);
+		result->ref();
+	}
+	return reinterpret_cast<jlong>(result);
 }
 
 JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeIsIdentity(JNIEnv *, jclass, jlong cptr)
@@ -916,6 +2346,70 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Matrix_nativePostMult(JN
     {
         m->postMult(*rhs);
     }
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativePreMultVec3(JNIEnv *, jclass, jlong cptr, jlong vec)
+{
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+    RefVec3 *rhs = reinterpret_cast<RefVec3 *>(vec);
+    RefVec3 *r = new RefVec3();
+
+    if(m != 0)
+    {
+    	osg::Vec3 res = m->preMult(*rhs);
+    	r->set(res.x(),res.y(),res.z());
+    }
+
+    r->ref();
+    return reinterpret_cast<jlong>(r);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativePostMultVec3(JNIEnv *, jclass, jlong cptr, jlong vec)
+{
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+    RefVec3 *rhs = reinterpret_cast<RefVec3 *>(vec);
+    RefVec3 *r = new RefVec3();
+
+    if(m != 0)
+    {
+        osg::Vec3 res = m->postMult(*rhs);
+        r->set(res.x(),res.y(),res.z());
+    }
+
+    r->ref();
+    return reinterpret_cast<jlong>(r);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativePreMultVec4(JNIEnv *, jclass, jlong cptr, jlong vec)
+{
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+    RefVec4 *rhs = reinterpret_cast<RefVec4 *>(vec);
+    RefVec4 *r = new RefVec4();
+
+    if(m != 0)
+    {
+        osg::Vec4 res = m->preMult(*rhs);
+        r->set(res.x(),res.y(),res.z(),res.w());
+    }
+
+    r->ref();
+    return reinterpret_cast<jlong>(r);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_core_Matrix_nativePostMultVec4(JNIEnv *, jclass, jlong cptr, jlong vec)
+{
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(cptr);
+    RefVec4 *rhs = reinterpret_cast<RefVec4 *>(vec);
+    RefVec4 *r = new RefVec4();
+
+    if(m != 0)
+    {
+    	osg::Vec4 res = m->postMult(*rhs);
+        r->set(res.x(),res.y(),res.z(),res.w());
+    }
+
+    r->ref();
+    return reinterpret_cast<jlong>(r);
 }
 
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Matrix_nativeMakeLookAt(JNIEnv *, jclass, jlong cptr,
@@ -1218,6 +2712,70 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_core_Image_nativeDirty(JNIEnv
 	{
 		im->dirty();
 	}
+}
+
+JNIEXPORT jbyte JNICALL Java_org_openscenegraph_osg_core_Image_nativeGetRed(JNIEnv* env, jclass, jlong cptr, jint s, jint t, jint r)
+{
+	unsigned char result = 0;
+	osg::Image *im = reinterpret_cast<osg::Image *>(cptr);
+	if(im != 0)
+	{
+		result = (unsigned char)(im->getColor(s,t,r).x());
+	}
+	return jbyte(result);
+}
+
+JNIEXPORT jbyte JNICALL Java_org_openscenegraph_osg_core_Image_nativeGetGreen(JNIEnv* env, jclass, jlong cptr, jint s, jint t, jint r)
+{
+	unsigned char result = 0;
+	osg::Image *im = reinterpret_cast<osg::Image *>(cptr);
+	if(im != 0)
+	{
+		result = (unsigned char)(im->getColor(s,t,r).y());
+	}
+	return jbyte(result);
+}
+
+JNIEXPORT jbyte JNICALL Java_org_openscenegraph_osg_core_Image_nativeGetBlue(JNIEnv* env, jclass, jlong cptr, jint s, jint t, jint r)
+{
+	unsigned char result = 0;
+	osg::Image *im = reinterpret_cast<osg::Image *>(cptr);
+	if(im != 0)
+	{
+		result = (unsigned char)(im->getColor(s,t,r).z());
+	}
+	return jbyte(result);
+}
+
+JNIEXPORT jbyte JNICALL Java_org_openscenegraph_osg_core_Image_nativeGetAlpha(JNIEnv* env, jclass, jlong cptr, jint s, jint t, jint r)
+{
+	unsigned char result = 0;
+	osg::Image *im = reinterpret_cast<osg::Image *>(cptr);
+	if(im != 0)
+	{
+		result = (unsigned char)(im->getColor(s,t,r).w());
+	}
+	return jbyte(result);
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Image_nativeS(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Image *im = reinterpret_cast<osg::Image *>(cptr);
+	if(im != 0)
+	{
+		return im->s();
+	}
+	return 0;
+}
+
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_core_Image_nativeT(JNIEnv* env, jclass, jlong cptr)
+{
+	osg::Image *im = reinterpret_cast<osg::Image *>(cptr);
+	if(im != 0)
+	{
+		return im->t();
+	}
+	return 0;
 }
 
 }

--- a/org.openscenegraph.android/jni/JNIosgDB.cpp
+++ b/org.openscenegraph.android/jni/JNIosgDB.cpp
@@ -20,11 +20,17 @@
 #include <jni.h>
 #include <android/log.h>
 
+#include <osg/io_utils>
+#include <osg/ImageUtils>
+
 #include <osgDB/ReadFile>
+#include <osgDB/WriteFile>
 
 #include "JNIUtils.h"
+#include <stdlib.h>
+#include <sstream>
 
-#define  LOG_TAG    "org.openscenegraph.osg.db.JNIosgDB"
+#define  LOG_TAG    "org.openscenegraph.osg.db"
 #define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO,LOG_TAG,__VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,LOG_TAG,__VA_ARGS__)
 
@@ -33,6 +39,10 @@ USE_OSGPLUGIN(ive)
 USE_OSGPLUGIN(osg2)
 USE_OSGPLUGIN(osg)
 USE_OSGPLUGIN(rgb)
+USE_OSGPLUGIN(bmp)
+USE_OSGPLUGIN(tga)
+USE_OSGPLUGIN(gif)
+USE_OSGPLUGIN(jpeg)
 USE_OSGPLUGIN(OpenFlight)
 
 #ifdef USE_FREETYPE
@@ -83,6 +93,42 @@ JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_db_ReadFile_nativeReadNodeFi
 	node->ref();
 	return reinterpret_cast<jlong>(node);
 
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_db_ReadFile_nativeReadImageFile(JNIEnv *env, jclass, jstring filename)
+{
+	//__android_log_write(ANDROID_LOG_INFO,LOG_TAG,jstring2string(env,filename).c_str());
+	osg::Image* node = osgDB::readImageFile(jstring2string(env,filename));
+	if(node == 0)
+	{
+		LOGE("Error loading image");
+		return 0;
+	}
+	node->ref();
+	return reinterpret_cast<jlong>(node);
+
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_db_WriteFile_nativeWriteNodeFile(JNIEnv* env, jclass, jstring filename, jlong node_cptr)
+{
+	#define LOG_TAG "org.openscenegraph.osg.db"
+	osg::Node* node = reinterpret_cast<osg::Node*>(node_cptr);
+	if(node!=0)
+	{
+		return osgDB::writeNodeFile(*node, jstring2string(env,filename));
+	}
+	return false;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_openscenegraph_osg_db_WriteFile_nativeWriteImageFile(JNIEnv* env, jclass, jstring filename, jlong image_cptr)
+{
+	#define LOG_TAG "org.openscenegraph.osg.db"
+	osg::Image* image = reinterpret_cast<osg::Image*>(image_cptr);
+	if(image!=NULL)
+	{
+		return osgDB::writeImageFile(*image, jstring2string(env,filename));
+	}
+	return false;
 }
 
 }

--- a/org.openscenegraph.android/jni/JNIosgViewer.cpp
+++ b/org.openscenegraph.android/jni/JNIosgViewer.cpp
@@ -19,20 +19,96 @@
 
 #include <jni.h>
 #include <android/log.h>
+#include "screenview.h"
 
+#include "JNIUtils.h"
+#include <stdlib.h>
+#include <sstream>
+
+#include <osg/ref_ptr>
 #include <osg/observer_ptr>
 #include <osg/Version>
 #include <osg/DisplaySettings>
 
+#include <osg/CoordinateSystemNode>
+#include <osg/ref_ptr>
+#include <osg/Array>
+
+#include <osg/io_utils>
+#include <osg/ImageUtils>
+#include <osgGA/StateSetManipulator>
+#include <osgViewer/Viewer>
+#include <osgViewer/ViewerEventHandlers>
+#include <osg/GraphicsContext>
+#include <osg/Texture2D>
+
+#include <osgDB/ReadFile>
+#include <osgDB/WriteFile>
+
+#include <osg/Referenced>
+#include <osg/Vec3>
+#include <osg/Image>
+#include <osg/State>
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
 
+//#include <osgGA/MatrixManipulator>
+#include <osgGA/CameraManipulator>
 #include <osgGA/MultiTouchTrackballManipulator>
 #include <osgGA/GUIEventAdapter>
 #include <osgGA/StateSetManipulator>
 
+#include <osg/Vec2>
+#include <osg/Vec3>
+#include <osg/Vec4>
+#include <osgUtil/IntersectionVisitor>
+#include <osgUtil/IntersectVisitor>
+#include <osgUtil/LineSegmentIntersector>
 
-#define  LOG_TAG    "org.openscenegraph.osg.viewer.JNIViewer"
+
+USE_OSGPLUGIN(ive)
+USE_OSGPLUGIN(osg2)
+USE_OSGPLUGIN(osg)
+USE_OSGPLUGIN(rgb)
+USE_OSGPLUGIN(bmp)
+USE_OSGPLUGIN(tga)
+USE_OSGPLUGIN(gif)
+USE_OSGPLUGIN(jpeg)
+USE_OSGPLUGIN(OpenFlight)
+
+#ifdef USE_FREETYPE
+    USE_OSGPLUGIN(freetype)
+#endif
+
+USE_DOTOSGWRAPPER_LIBRARY(osg)
+//USE_DOTOSGWRAPPER_LIBRARY(osgAnimation)
+USE_DOTOSGWRAPPER_LIBRARY(osgFX)
+USE_DOTOSGWRAPPER_LIBRARY(osgParticle)
+USE_DOTOSGWRAPPER_LIBRARY(osgShadow)
+USE_DOTOSGWRAPPER_LIBRARY(osgSim)
+USE_DOTOSGWRAPPER_LIBRARY(osgTerrain)
+USE_DOTOSGWRAPPER_LIBRARY(osgText)
+USE_DOTOSGWRAPPER_LIBRARY(osgViewer)
+USE_DOTOSGWRAPPER_LIBRARY(osgVolume)
+USE_DOTOSGWRAPPER_LIBRARY(osgWidget)
+
+USE_SERIALIZER_WRAPPER_LIBRARY(osg)
+//USE_SERIALIZER_WRAPPER_LIBRARY(osgUtil)
+//USE_SERIALIZER_WRAPPER_LIBRARY(osgGA)
+//USE_SERIALIZER_WRAPPER_LIBRARY(osgViewer)
+//USE_SERIALIZER_WRAPPER_LIBRARY(osgUI)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgAnimation)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgFX)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgManipulator)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgParticle)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgShadow)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgSim)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgTerrain)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgText)
+USE_SERIALIZER_WRAPPER_LIBRARY(osgVolume)
+//USE_SERIALIZER_WRAPPER_LIBRARY(osgPresentation)
+
+#define  LOG_TAG    "org.openscenegraph.osg.viewer"
 #define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO,LOG_TAG,__VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,LOG_TAG,__VA_ARGS__)
 
@@ -71,10 +147,42 @@ public:
 extern "C"
 {
 
+/*
+ * osgViewer::ViewerBase
+ */
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_ViewerBase_nativeFrame(JNIEnv *, jclass, jlong cptr)
+{
+	osgViewer::ViewerBase *v = reinterpret_cast<osgViewer::ViewerBase*> (cptr);
+	if (v == NULL)
+		return;
+
+	v->frame();
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_ViewerBase_nativeSetUpViewerAsEmbedded(JNIEnv *, jclass, jlong cptr, jint x, jint y, jint width, jint height)
+{
+    osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (v == NULL)
+        return;
+    v->setUpViewerAsEmbeddedInWindow(x, y, width, height);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_ViewerBase_nativeSetViewport(JNIEnv *, jclass, jlong cptr, jint x, jint y, jint width, jint height)
+{
+    osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (v == NULL)
+        return;
+    v->getEventQueue()->windowResize(x, y, width, height);
+}
+
+
+/*
+ * osgViewer::Viewer
+ */
 JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeCreateViewer(JNIEnv *, jclass)
 {
-    osg::setNotifyLevel(osg::INFO);
-    osg::setNotifyHandler( new OsgMsgNotifyHandler() );
+    //osg::setNotifyLevel(osg::INFO);
+    //osg::setNotifyHandler( new OsgMsgNotifyHandler() );
     osgViewer::Viewer *viewer = new osgViewer::Viewer();
     viewer->setSceneData(new osg::Group());
     OSG_NOTICE << "OSG Version:" << osgGetVersion() << std::endl;
@@ -88,6 +196,67 @@ JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeCreateVi
     viewer->addEventHandler( new osgGA::StateSetManipulator(viewer->getCamera()->getOrCreateStateSet()) );
     viewer->ref();
     return reinterpret_cast<jlong> (viewer);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeSetViewMatrix(JNIEnv* env, jclass, jlong cptr, jlong matrix_ptr)
+{
+	osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer *>(cptr);
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(matrix_ptr);
+    if(viewer != 0 && m!=0)
+    {
+    	osg::Matrixd _mat = osg::Matrixd(*m);
+    	osg::Matrixd _pretransform = osg::Matrixd::scale(1,-1,-1);
+    	osg::Matrixd _inverse = osg::Matrixd::inverse(_mat);
+    	osg::Matrixd _transformation = _inverse*_pretransform;
+    	osg::Vec3d eye, center, up;
+    	_transformation.getLookAt(eye, center, up);
+
+
+        osgGA::MultiTouchTrackballManipulator* _view_interaction = reinterpret_cast<osgGA::MultiTouchTrackballManipulator*>(viewer->getCameraManipulator());
+        _view_interaction->setHomePosition(eye,center,up);
+        viewer->home();
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeSetViewMatrixDistance(JNIEnv* env, jclass, jlong cptr, jlong matrix_ptr, jdouble distance)
+{
+	osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer *>(cptr);
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(matrix_ptr);
+    if(viewer != 0 && m!=0)
+    {
+    	osg::Matrixd _mat = osg::Matrixd(*m);
+    	//osg::Matrixd _pretransform = osg::Matrixd::scale(1,-1,-1);
+    	//osg::Matrixd _inverse = osg::Matrixd::inverse(_mat);
+    	//osg::Matrixd _transformation = _inverse * _pretransform;
+    	osg::Vec3d eye, center, up;
+    	viewer->getCamera()->getViewMatrixAsLookAt(eye,center,up);
+    	//LOGI("[BEFORE] Eye: (%f,%f,%f) - Center: (%f,%f,%f) - Up: (%f,%f,%f)",eye.x(), eye.y(), eye.z(), center.x(), center.y(), center.z(), up.x(), up.y(), up.z());
+
+    	//double* data = (double*)(_mat.ptr());
+		//LOGI("[%f,%f,%f,%f]",data[0],data[1],data[2],data[3]);
+		//LOGI("[%f,%f,%f,%f]",data[4],data[5],data[6],data[7]);
+		//LOGI("[%f,%f,%f,%f]",data[8],data[9],data[10],data[11]);
+		//LOGI("[%f,%f,%f,%f]",data[12],data[13],data[14],data[15]);
+
+    	viewer->getCamera()->setViewMatrix(_mat);
+    	viewer->getCamera()->getViewMatrixAsLookAt(eye,center,up);
+    	LOGI("Eye: (%f,%f,%f) - Center: (%f,%f,%f) - Up: (%f,%f,%f)",eye.x(), eye.y(), eye.z(), center.x(), center.y(), center.z(), up.x(), up.y(), up.z());
+
+        osgGA::MultiTouchTrackballManipulator* _view_interaction = reinterpret_cast<osgGA::MultiTouchTrackballManipulator*>(viewer->getCameraManipulator());
+        _view_interaction->setDistance(distance);
+        _view_interaction->setHomePosition(eye,center,up);
+        viewer->home();
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeSetPerspectiveMatrix(JNIEnv* env, jclass, jlong cptr, jint width, jint height, jfloat fov)
+{
+    osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (viewer == NULL)
+        return;
+	viewer->getCamera()->setProjectionMatrix(osg::Matrixd::perspective(osg::RadiansToDegrees(fov), jfloat(width)/jfloat(height), 0.1, 1500.0));
+	//osg::Matrixd lookat_matrix = osg::Matrixd::lookAt(osg::Vec3d(0.0, 0.0, -1.0), osg::Vec3d(0.0, 0.0, 1.0), osg::Vec3d(0.0, 1.0, 0.0));
+	//viewer->getCamera()->setViewMatrix(lookat_matrix);
 }
 
 JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeSetDefaultSettings(JNIEnv *, jclass, jlong cptr)
@@ -188,6 +357,319 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeKeyboard(
 		v->getEventQueue()->keyRelease((osgGA::GUIEventAdapter::KeySymbol) key);
 }
 
+//JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_Viewer_nativeGetCamera(JNIEnv* env, class, jlong cptr)
+//{
+//	osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+//	jlong address = 0;
+//	if (v == NULL)
+//		return address;
+//
+//	osg::Camera* c = v->getCamera();
+//	if(c!=NULL)
+//	{
+//		address = reinterpret_cast<jlong>(c);
+//	}
+//	return address;
+//}
+
+//////////////////////////
+// osg::OffScreenViewer //
+//////////////////////////
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeCreatePBufferViewer(JNIEnv* env, jclass, jint width, jint height, jfloat fov)
+{
+	osg::setNotifyLevel(osg::WARN);
+    //osg::setNotifyLevel(osg::INFO);
+    osg::setNotifyHandler( new OsgMsgNotifyHandler() );
+    osgViewer::Viewer *viewer = new osgViewer::Viewer();
+    viewer->setThreadingModel(osgViewer::Viewer::SingleThreaded);
+    viewer->setSceneData(new osg::Group());
+    //viewer->getCamera()->getOrCreateStateSet()->setGlobalDefaults();
+
+
+    viewer->getCamera()->setComputeNearFarMode(osgUtil::CullVisitor::DO_NOT_COMPUTE_NEAR_FAR);
+    viewer->getCamera()->setCullMask(0xffffffff);
+    viewer->getCamera()->setCullMaskLeft(0x00000001);
+    viewer->getCamera()->setCullMaskRight(0x00000002);
+
+
+	viewer->getCamera()->setClearColor(osg::Vec4f(0.25f, 0.25f, 0.25f, 1.0f));
+	viewer->getCamera()->setClearMask(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+
+	//viewer->getCamera()->setViewport(0,0,width,height);
+	//viewer->getCamera()->setDrawBuffer(GL_BACK);
+
+
+	//viewer->getCamera()->setProjectionMatrix(osg::Matrixd::perspective(osg::RadiansToDegrees(fov), jfloat(width)/jfloat(height), 0.1, 150.0));
+	//osg::Matrixd lookat_matrix = osg::Matrixd::lookAt(osg::Vec3d(0.0, 0.0, -1.0), osg::Vec3d(0.0, 0.0, 1.0), osg::Vec3d(0.0, 1.0, 0.0));
+	//viewer->getCamera()->setViewMatrix(lookat_matrix);
+	LOGI("non-windowed context created.");
+
+
+    viewer->setCameraManipulator(0x0);
+    viewer->addEventHandler( new osgGA::StateSetManipulator(viewer->getCamera()->getOrCreateStateSet()) );
+    viewer->ref();
+    return reinterpret_cast<jlong> (viewer);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetUpViewerAsEmbedded(JNIEnv *, jclass, jlong cptr, jint x, jint y, jint width, jint height)
+{
+    osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (v == NULL)
+        return;
+    v->setUpViewerAsEmbeddedInWindow(x, y, width, height);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetViewport(JNIEnv *, jclass, jlong cptr, jint x, jint y, jint width, jint height)
+{
+    osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (v == NULL)
+        return;
+    //v->getEventQueue()->windowResize(x, y, width, height);
+    v->getCamera()->setViewport(x,y,width,height);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetView(JNIEnv* env, jclass, jlong cptr, jint width, jint height, jfloat fov)
+{
+    osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (viewer == NULL)
+        return;
+	viewer->getCamera()->setProjectionMatrix(osg::Matrixd::perspective(osg::RadiansToDegrees(fov), jfloat(width)/jfloat(height), 0.1, 1500.0));
+	osg::Matrixd lookat_matrix = osg::Matrixd::lookAt(osg::Vec3d(0.0, 0.0, -1.0), osg::Vec3d(0.0, 0.0, 1.0), osg::Vec3d(0.0, 1.0, 0.0));
+	viewer->getCamera()->setViewMatrix(lookat_matrix);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetupCallback(JNIEnv* env, jclass, jlong cptr)
+{
+    osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+    if (v == NULL)
+        return;
+	WindowCaptureCallback* _callback = new WindowCaptureCallback(WindowCaptureCallback::DOUBLE_PBO, WindowCaptureCallback::START_FRAME, GL_BACK);
+	if(_callback == NULL)
+	{
+		LOGE("Error setting callback function.");
+		return;
+	}
+	v->getCamera()->setFinalDrawCallback(_callback);
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeGetFrame(JNIEnv* env, jclass, jlong cptr, jlong matrix_ptr)
+{
+	osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer *>(cptr);
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(matrix_ptr);
+
+	if(viewer==0)
+	{
+		LOGE("Viewer unavailable.");
+		return 0;
+	}
+	if(m==0)
+	{
+		LOGE("Matrix unavailable.");
+		return 0;
+	}
+
+	osg::Matrixd _mat = osg::Matrixd(*m);
+
+	//render
+	viewer->getCamera()->setViewMatrix(_mat);
+	viewer->frame();
+	viewer->frame();
+
+	WindowCaptureCallback* _callback = reinterpret_cast<WindowCaptureCallback*>(viewer->getCamera()->getFinalDrawCallback());
+	jlong result;
+	osg::Image* data = NULL;
+	if(_callback != NULL)
+	{
+		data = _callback->getImage(viewer->getCamera()->getGraphicsContext());
+		while(data==NULL)
+		{
+			viewer->frame();
+			viewer->frame();
+			data = _callback->getImage(viewer->getCamera()->getGraphicsContext());
+		}
+		osg::Image* result_image = reinterpret_cast<osg::Image*>( data->clone ( osg::CopyOp::DEEP_COPY_ALL ) );
+		result_image->ref();
+		result = reinterpret_cast<jlong>( result_image );
+	}
+	else
+	{
+		LOGE("Callback unavailable.");
+		result = 0;
+	}
+	return result;
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeGetFrameImage(JNIEnv* env, jclass, jlong cptr)
+{
+	osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer *>(cptr);
+
+	if(viewer==0)
+	{
+		LOGE("Viewer unavailable.");
+		return 0;
+	}
+	WindowCaptureCallback* _callback = reinterpret_cast<WindowCaptureCallback*>(viewer->getCamera()->getFinalDrawCallback());
+	jlong result;
+	osg::Image* data = NULL;
+	if(_callback != NULL)
+	{
+		data = _callback->getImage(viewer->getCamera()->getGraphicsContext());
+		while(data==NULL)
+		{
+			viewer->frame();
+			viewer->frame();
+			data = _callback->getImage(viewer->getCamera()->getGraphicsContext());
+		}
+		osg::Image* result_image = reinterpret_cast<osg::Image*>( data->clone ( osg::CopyOp::DEEP_COPY_ALL ) );
+		result_image->ref();
+		result = reinterpret_cast<jlong>( result_image );
+	}
+	else
+	{
+		LOGE("Callback unavailable.");
+		result = 0;
+	}
+	return result;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetViewMatrix(JNIEnv* env, jclass, jlong cptr, jlong matrix_ptr)
+{
+	osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer *>(cptr);
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(matrix_ptr);
+    if(viewer != 0 && m!=0)
+    {
+    	osg::Matrixd _mat = osg::Matrixd(*m);
+    	//osg::Matrixd _pretransform = osg::Matrixd::scale(1,-1,-1);
+    	//osg::Matrixd _inverse = osg::Matrixd::inverse(_mat);
+    	//osg::Matrixd _transformation = _inverse * _pretransform;
+
+    	//double* data = (double*)(_mat.ptr());
+		//double* data = (double*)(_transformation.ptr());
+		//LOGI("[%f,%f,%f,%f]",data[0],data[1],data[2],data[3]);
+		//LOGI("[%f,%f,%f,%f]",data[4],data[5],data[6],data[7]);
+		//LOGI("[%f,%f,%f,%f]",data[8],data[9],data[10],data[11]);
+		//LOGI("[%f,%f,%f,%f]",data[12],data[13],data[14],data[15]);
+
+    	viewer->getCamera()->setViewMatrix(_mat);
+    	osg::Vec3 eye, center, up;
+    	viewer->getCamera()->getViewMatrixAsLookAt(eye,center,up);
+    	LOGI("Eye: (%f,%f,%f) - Center: (%f,%f,%f) - Up: (%f,%f,%f)",eye.x(), eye.y(), eye.z(), center.x(), center.y(), center.z(), up.x(), up.y(), up.z());
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetRenderMatrix(JNIEnv* env, jclass, jlong cptr, jlong matrix_ptr)
+{
+	osgViewer::Viewer *viewer = reinterpret_cast<osgViewer::Viewer *>(cptr);
+    osg::RefMatrixf *m = reinterpret_cast<osg::RefMatrixf *>(matrix_ptr);
+    if(viewer != 0 && m!=0)
+    {
+    	osg::Matrixd _mat = osg::Matrixd(*m);
+    	viewer->getCamera()->setViewMatrix(_mat);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeDisposeViewer(JNIEnv *, jclass, jlong cptr)
+{
+	osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+	if (v == NULL)
+		return;
+	v->unref();
+	//delete v;
+	//v = NULL;
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeSetSceneData(JNIEnv *, jclass, jlong viewer, jlong node)
+{
+	osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (viewer);
+	if (v == NULL)
+		return;
+	osg::Node *n = reinterpret_cast<osg::Node*>(node);
+	if (n == NULL)
+		return;
+	v->setSceneData(n);
+}
+
+JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeFrame(JNIEnv *, jclass, jlong cptr)
+{
+	osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+	if (v == NULL)
+		return;
+
+	v->frame();
+}
+
+JNIEXPORT jlong JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeGetCamera(JNIEnv *, jclass, jlong cptr)
+{
+	osgViewer::Viewer *v = reinterpret_cast<osgViewer::Viewer*> (cptr);
+	if (v == NULL)
+		return 0;
+	osg::Camera *camera;
+	camera = v->getCamera();
+	camera->ref();
+	return reinterpret_cast<jlong>(camera);
+}
+
+JNICALL jlong JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeRaycast(JNIEnv* env, jclass, jlong viewer_cptr, jlong camera_ptr, jlong vec2array_cptr)
+{
+	osg::Vec3Array* v3a = new osg::Vec3Array();
+	v3a->ref();
+
+	osgViewer::View* viewer = reinterpret_cast<osgViewer::View*>(viewer_cptr);
+	osg::Camera* cam = reinterpret_cast<osg::Camera*>(camera_ptr);
+	osg::Vec2Array* va = reinterpret_cast<osg::Vec2Array*>(vec2array_cptr);
+	osgUtil::LineSegmentIntersector::Intersections intersections;
+	for(uint i = 0; i < va->size(); i++)
+	{
+		if(i==0)
+		{
+			osg::Matrixf cmat = cam->getViewMatrix();
+			float* data = (float*)(cmat.ptr());
+			LOGI("[%f,%f,%f,%f]",data[0],data[1],data[2],data[3]);
+			LOGI("[%f,%f,%f,%f]",data[4],data[5],data[6],data[7]);
+			LOGI("[%f,%f,%f,%f]",data[8],data[9],data[10],data[11]);
+			LOGI("[%f,%f,%f,%f]",data[12],data[13],data[14],data[15]);
+	    	osg::Vec3 eye, center, up;
+	    	cam->getViewMatrixAsLookAt(eye,center,up);
+	    	LOGI("Eye: (%f,%f,%f) - Center: (%f,%f,%f) - Up: (%f,%f,%f)",eye.x(), eye.y(), eye.z(), center.x(), center.y(), center.z(), up.x(), up.y(), up.z());
+		}
+		viewer->computeIntersections(const_cast<const osg::Camera*>(cam), osgUtil::Intersector::WINDOW, va->at(i).x(), va->at(i).y(), intersections);
+		RefVec3 *refRes = new RefVec3();
+		if(intersections.empty() == false)
+		{
+			refRes->set(intersections.begin()->getWorldIntersectPoint().x(), intersections.begin()->getWorldIntersectPoint().y(), intersections.begin()->getWorldIntersectPoint().z());
+		}
+		else
+		{
+			refRes->set(DBL_MAX,DBL_MAX,DBL_MAX);
+		}
+		refRes->ref();
+		v3a->push_back(*refRes);
+	}
+
+	return reinterpret_cast<jlong>(v3a);
+}
+
+JNICALL jlong JNICALL Java_org_openscenegraph_osg_viewer_OffScreenViewer_nativeIntersections(JNIEnv* env, jclass, jlong scene_cptr, jlong vec2array_cptr, jlong tvec_cptr, jlong rquat_cptr)
+{
+	osg::Vec3Array* v3a = new osg::Vec3Array();
+	v3a->ref();
+
+	osg::Node* scene = reinterpret_cast<osg::Node*>(scene_cptr);
+	osg::Vec2Array* va = reinterpret_cast<osg::Vec2Array*>(vec2array_cptr);
+	osg::BoundingSphere bs = scene->getBound();
+	osgUtil::LineSegmentIntersector::Intersections intersections;
+	for(uint i = 0; i < va->size(); i++)
+	{
+
+	}
+
+	return reinterpret_cast<jlong>(v3a);
+}
+
+
+
+
 ///////////////////////////////////////////////////////////////////////////////
 //Touch Events
 ///////////////////////////////////////////////////////////////////////////////
@@ -287,6 +769,8 @@ JNIEXPORT void JNICALL Java_org_openscenegraph_osg_viewer_Viewer_native_1home(
 
         v->home();
 }
+
+
 
 
 
@@ -391,10 +875,11 @@ JNIEXPORT void  JNICALL Java_org_openscenegraph_osg_viewer_DisplaySettings_nativ
 	osg::DisplaySettings* ds=  reinterpret_cast<osg::DisplaySettings*>(cptr);
 	ds->setNumMultiSamples(samples);	
 }
-JNIEXPORT jint  JNICALL Java_org_openscenegraph_osg_viewer_DisplaySettings_native_1getNumMultiSamples(JNIEnv *, jclass,jlong cptr)
+JNIEXPORT jint JNICALL Java_org_openscenegraph_osg_viewer_DisplaySettings_native_1getNumMultiSamples(JNIEnv *, jclass,jlong cptr)
 {
 	osg::DisplaySettings* ds=  reinterpret_cast<osg::DisplaySettings*>(cptr);
 	return ds->getNumMultiSamples();	
 }
+
 
 }

--- a/org.openscenegraph.android/jni/screenview.cpp
+++ b/org.openscenegraph.android/jni/screenview.cpp
@@ -1,0 +1,389 @@
+/*
+ * screenview.cpp
+ *
+ *  Created on: Aug 13, 2015
+ *      Author: christian
+ */
+
+#include "screenview.h"
+
+void WindowCaptureCallback::ContextData::updateTimings(osg::Timer_t tick_start,
+                                                       osg::Timer_t tick_afterReadPixels,
+                                                       osg::Timer_t tick_afterMemCpy,
+                                                       unsigned int dataSize)
+{
+    if (!_reportTimingFrequency) return;
+
+    double timeForReadPixels = osg::Timer::instance()->delta_s(tick_start, tick_afterReadPixels);
+    double timeForFullCopy = osg::Timer::instance()->delta_s(tick_start, tick_afterMemCpy);
+    double timeForMemCpy = osg::Timer::instance()->delta_s(tick_afterReadPixels, tick_afterMemCpy);
+
+    _timeForReadPixels += timeForReadPixels;
+    _timeForFullCopy += timeForFullCopy;
+    _timeForMemCpy += timeForMemCpy;
+
+    ++_numTimeValuesRecorded;
+
+    if (_numTimeValuesRecorded==_reportTimingFrequency)
+    {
+        timeForReadPixels = _timeForReadPixels/double(_numTimeValuesRecorded);
+        timeForFullCopy = _timeForFullCopy/double(_numTimeValuesRecorded);
+        timeForMemCpy = _timeForMemCpy/double(_numTimeValuesRecorded);
+
+        double averageFrameTime =  osg::Timer::instance()->delta_s(_previousFrameTick, tick_afterMemCpy)/double(_numTimeValuesRecorded);
+        double fps = 1.0/averageFrameTime;
+        _previousFrameTick = tick_afterMemCpy;
+
+        _timeForReadPixels = 0.0;
+        _timeForFullCopy = 0.0;
+        _timeForMemCpy = 0.0;
+
+        _numTimeValuesRecorded = 0;
+
+        double numMPixels = double(_width * _height) / 1000000.0;
+        double numMb = double(dataSize) / (1024*1024);
+    }
+
+}
+
+void WindowCaptureCallback::ContextData::readPixels()
+{
+    // std::cout<<"readPixels("<<_fileName<<" image "<<_currentImageIndex<<" "<<_currentPboIndex<<std::endl;
+
+    unsigned int nextImageIndex = (_currentImageIndex+1)%_imageBuffer.size();
+    unsigned int nextPboIndex = _pboBuffer.empty() ? 0 : (_currentPboIndex+1)%_pboBuffer.size();
+
+    int width=0, height=0;
+    getSize(_gc, width, height);
+    if (width!=_width || _height!=height)
+    {
+        std::cout<<"   Window resized "<<width<<", "<<height<<std::endl;
+        _width = width;
+        _height = height;
+    }
+
+    osg::Image* image = _imageBuffer[_currentImageIndex].get();
+
+    osg::Timer_t tick_start = osg::Timer::instance()->tick();
+
+#if 1
+    image->readPixels(0,0,_width,_height,_pixelFormat,_type);
+
+#endif
+
+    osg::Timer_t tick_afterReadPixels = osg::Timer::instance()->tick();
+
+    updateTimings(tick_start, tick_afterReadPixels, tick_afterReadPixels, image->getTotalSizeInBytes());
+
+    _image_available = true;
+    _currentImageToTransfer = reinterpret_cast<osg::Image*>( image->clone ( osg::CopyOp::DEEP_COPY_ALL ) );
+
+    if (!_fileName.empty())
+    {
+        // osgDB::writeImageFile(*image, _fileName);
+    }
+
+    _currentImageIndex = nextImageIndex;
+    _currentPboIndex = nextPboIndex;
+}
+
+void WindowCaptureCallback::ContextData::singlePBO(osg::GLExtensions* ext)
+{
+    // std::cout<<"singelPBO(  "<<_fileName<<" image "<<_currentImageIndex<<" "<<_currentPboIndex<<std::endl;
+
+    unsigned int nextImageIndex = (_currentImageIndex+1)%_imageBuffer.size();
+
+    int width=0, height=0;
+    getSize(_gc, width, height);
+    if (width!=_width || _height!=height)
+    {
+        //std::cout<<"   Window resized "<<width<<", "<<height<<std::endl;
+        _width = width;
+        _height = height;
+    }
+
+    GLuint& pbo = _pboBuffer[0];
+
+    osg::Image* image = _imageBuffer[_currentImageIndex].get();
+    if (image->s() != _width ||
+        image->t() != _height)
+    {
+#ifdef DEBUG
+        osg::notify(osg::NOTICE)<<"Allocating image "<<std::endl;
+#endif
+        image->allocateImage(_width, _height, 1, _pixelFormat, _type);
+
+        if (pbo!=0)
+        {
+#ifdef DEBUG
+            osg::notify(osg::NOTICE)<<"deleting pbo "<<pbo<<std::endl;
+#endif
+            ext->glDeleteBuffers (1, &pbo);
+            pbo = 0;
+        }
+    }
+
+
+    if (pbo==0)
+    {
+        ext->glGenBuffers(1, &pbo);
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, pbo);
+        ext->glBufferData(GL_PIXEL_PACK_BUFFER_ARB, image->getTotalSizeInBytes(), 0, GL_STREAM_READ);
+#ifdef DEBUG
+        osg::notify(osg::NOTICE)<<"Generating pbo "<<pbo<<std::endl;
+#endif
+    }
+    else
+    {
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, pbo);
+    }
+
+    osg::Timer_t tick_start = osg::Timer::instance()->tick();
+
+#if 1
+    glReadPixels(0, 0, _width, _height, _pixelFormat, _type, 0);
+#endif
+
+    osg::Timer_t tick_afterReadPixels = osg::Timer::instance()->tick();
+
+    GLubyte* src = (GLubyte*)ext->glMapBuffer(GL_PIXEL_PACK_BUFFER_ARB,
+                                              GL_READ_ONLY_ARB);
+    if(src)
+    {
+        memcpy(image->data(), src, image->getTotalSizeInBytes());
+
+        ext->glUnmapBuffer(GL_PIXEL_PACK_BUFFER_ARB);
+    }
+
+    ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, 0);
+
+    osg::Timer_t tick_afterMemCpy = osg::Timer::instance()->tick();
+
+    updateTimings(tick_start, tick_afterReadPixels, tick_afterMemCpy, image->getTotalSizeInBytes());
+
+    if (!_fileName.empty())
+    {
+        // osgDB::writeImageFile(*image, _fileName);
+    }
+
+
+    _currentImageIndex = nextImageIndex;
+}
+
+void WindowCaptureCallback::ContextData::multiPBO(osg::GLExtensions* ext)
+{
+    // std::cout<<"multiPBO(  "<<_fileName<<" image "<<_currentImageIndex<<" "<<_currentPboIndex<<std::endl;
+    unsigned int nextImageIndex = (_currentImageIndex+1)%_imageBuffer.size();
+    unsigned int nextPboIndex = (_currentPboIndex+1)%_pboBuffer.size();
+
+    int width=0, height=0;
+    getSize(_gc, width, height);
+    if (width!=_width || _height!=height)
+    {
+        _width = width;
+        _height = height;
+    }
+
+    GLuint& copy_pbo = _pboBuffer[_currentPboIndex];
+    GLuint& read_pbo = _pboBuffer[nextPboIndex];
+
+    osg::Image* image = _imageBuffer[_currentImageIndex].get();
+    if (image->s() != _width ||
+        image->t() != _height)
+    {
+#ifdef DEBUG
+        osg::notify(osg::NOTICE)<<"Allocating image "<<std::endl;
+#endif
+        image->allocateImage(_width, _height, 1, _pixelFormat, _type);
+
+        if (read_pbo!=0)
+        {
+#ifdef DEBUG
+            osg::notify(osg::NOTICE)<<"deleting pbo "<<read_pbo<<std::endl;
+#endif
+            ext->glDeleteBuffers (1, &read_pbo);
+            read_pbo = 0;
+        }
+
+        if (copy_pbo!=0)
+        {
+#ifdef DEBUG
+            osg::notify(osg::NOTICE)<<"deleting pbo "<<copy_pbo<<std::endl;
+#endif
+            ext->glDeleteBuffers (1, &copy_pbo);
+            copy_pbo = 0;
+        }
+    }
+
+
+    bool doCopy = copy_pbo!=0;
+    if (copy_pbo==0)
+    {
+        ext->glGenBuffers(1, &copy_pbo);
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, copy_pbo);
+        ext->glBufferData(GL_PIXEL_PACK_BUFFER_ARB, image->getTotalSizeInBytes(), 0, GL_STREAM_READ);
+#ifdef DEBUG
+        osg::notify(osg::NOTICE)<<"Generating pbo "<<read_pbo<<std::endl;
+#endif
+    }
+
+    if (read_pbo==0)
+    {
+        ext->glGenBuffers(1, &read_pbo);
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, read_pbo);
+        ext->glBufferData(GL_PIXEL_PACK_BUFFER_ARB, image->getTotalSizeInBytes(), 0, GL_STREAM_READ);
+#ifdef DEBUG
+        osg::notify(osg::NOTICE)<<"Generating pbo "<<read_pbo<<std::endl;
+#endif
+    }
+    else
+    {
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, read_pbo);
+    }
+
+    osg::Timer_t tick_start = osg::Timer::instance()->tick();
+
+#if 1
+    glReadPixels(0, 0, _width, _height, _pixelFormat, _type, 0);
+#endif
+
+    osg::Timer_t tick_afterReadPixels = osg::Timer::instance()->tick();
+
+    if (doCopy)
+    {
+
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, copy_pbo);
+
+        GLubyte* src = (GLubyte*)ext->glMapBuffer(GL_PIXEL_PACK_BUFFER_ARB,
+                                                  GL_READ_ONLY_ARB);
+        if(src)
+        {
+            memcpy(image->data(), src, image->getTotalSizeInBytes());
+            ext->glUnmapBuffer(GL_PIXEL_PACK_BUFFER_ARB);
+        }
+
+        if (!_fileName.empty())
+        {
+            // osgDB::writeImageFile(*image, _fileName);
+        }
+    }
+
+    ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, 0);
+
+    osg::Timer_t tick_afterMemCpy = osg::Timer::instance()->tick();
+
+    updateTimings(tick_start, tick_afterReadPixels, tick_afterMemCpy, image->getTotalSizeInBytes());
+
+    _image_available = true;
+    _currentImageToTransfer = reinterpret_cast<osg::Image*>( image->clone ( osg::CopyOp::DEEP_COPY_ALL ) );
+#ifdef DEBUG
+    std::cout << "Rendered via multiple PBO's." << std::endl;
+#endif
+
+    _currentImageIndex = nextImageIndex;
+    _currentPboIndex = nextPboIndex;
+}
+
+void addCallbackToViewer(osgViewer::ViewerBase& viewer, WindowCaptureCallback* callback)
+{
+
+    if (callback->getFramePosition()==WindowCaptureCallback::START_FRAME)
+    {
+        osgViewer::ViewerBase::Windows windows;
+        viewer.getWindows(windows);
+        for(osgViewer::ViewerBase::Windows::iterator itr = windows.begin();
+            itr != windows.end();
+            ++itr)
+        {
+            osgViewer::GraphicsWindow* window = *itr;
+            osg::GraphicsContext::Cameras& cameras = window->getCameras();
+            osg::Camera* firstCamera = 0;
+            for(osg::GraphicsContext::Cameras::iterator cam_itr = cameras.begin();
+                cam_itr != cameras.end();
+                ++cam_itr)
+            {
+                if (firstCamera)
+                {
+                    if ((*cam_itr)->getRenderOrder() < firstCamera->getRenderOrder())
+                    {
+                        firstCamera = (*cam_itr);
+                    }
+                    if ((*cam_itr)->getRenderOrder() == firstCamera->getRenderOrder() &&
+                        (*cam_itr)->getRenderOrderNum() < firstCamera->getRenderOrderNum())
+                    {
+                        firstCamera = (*cam_itr);
+                    }
+                }
+                else
+                {
+                    firstCamera = *cam_itr;
+                }
+            }
+
+            if (firstCamera)
+            {
+#ifdef DEBUG
+                osg::notify(osg::NOTICE)<<"First camera "<<firstCamera<<std::endl;
+#endif
+                firstCamera->setInitialDrawCallback(callback);
+            }
+            else
+            {
+#ifdef DEBUG
+                osg::notify(osg::NOTICE)<<"No camera found"<<std::endl;
+#endif
+            }
+        }
+    }
+    else
+    {
+        osgViewer::ViewerBase::Windows windows;
+        viewer.getWindows(windows);
+        for(osgViewer::ViewerBase::Windows::iterator itr = windows.begin();
+            itr != windows.end();
+            ++itr)
+        {
+            osgViewer::GraphicsWindow* window = *itr;
+            osg::GraphicsContext::Cameras& cameras = window->getCameras();
+            osg::Camera* lastCamera = 0;
+            for(osg::GraphicsContext::Cameras::iterator cam_itr = cameras.begin();
+                cam_itr != cameras.end();
+                ++cam_itr)
+            {
+                if (lastCamera)
+                {
+                    if ((*cam_itr)->getRenderOrder() > lastCamera->getRenderOrder())
+                    {
+                        lastCamera = (*cam_itr);
+                    }
+                    if ((*cam_itr)->getRenderOrder() == lastCamera->getRenderOrder() &&
+                        (*cam_itr)->getRenderOrderNum() >= lastCamera->getRenderOrderNum())
+                    {
+                        lastCamera = (*cam_itr);
+                    }
+                }
+                else
+                {
+                    lastCamera = *cam_itr;
+                }
+            }
+
+            if (lastCamera)
+            {
+#ifdef DEBUG
+                osg::notify(osg::NOTICE)<<"Last camera "<<lastCamera<<std::endl;
+#endif
+                lastCamera->setFinalDrawCallback(callback);
+            }
+            else
+            {
+#ifdef DEBUG
+                osg::notify(osg::NOTICE)<<"No camera found"<<std::endl;
+#endif
+            }
+        }
+    }
+}
+
+
+

--- a/org.openscenegraph.android/jni/screenview.h
+++ b/org.openscenegraph.android/jni/screenview.h
@@ -1,0 +1,273 @@
+/*
+ * screenview.h
+ *
+ *  Created on: Aug 13, 2015
+ *      Author: christian
+ */
+
+#ifndef SCREENVIEW_H_
+#define SCREENVIEW_H_
+
+#include <osg/GL>
+#include <osg/GLDefines>
+#include <osg/GLExtensions>
+#include <osg/GL2Extensions>
+#include <osg/GLObjects>
+#include <osg/BufferObject>
+#include <osg/FrameBufferObject>
+
+#include <osgDB/ReadFile>
+#include <osgDB/WriteFile>
+
+#include <osgUtil/Optimizer>
+#include <osg/CoordinateSystemNode>
+
+#include <osg/Switch>
+#include <osgText/Text>
+
+#include <osgViewer/Viewer>
+#include <osgViewer/ViewerEventHandlers>
+
+#include <osgGA/TrackballManipulator>
+#include <osgGA/FlightManipulator>
+#include <osgGA/DriveManipulator>
+#include <osgGA/KeySwitchMatrixManipulator>
+#include <osgGA/StateSetManipulator>
+#include <osgGA/AnimationPathManipulator>
+#include <osgGA/TerrainManipulator>
+
+#include <jni.h>
+#include <android/log.h>
+
+class WindowCaptureCallback : public osg::Camera::DrawCallback
+{
+    public:
+
+        enum Mode
+        {
+            READ_PIXELS,
+            SINGLE_PBO,
+            DOUBLE_PBO,
+            TRIPLE_PBO
+        };
+
+        enum FramePosition
+        {
+            START_FRAME,
+            END_FRAME
+        };
+
+        struct ContextData : public osg::Referenced
+        {
+
+            inline ContextData(osg::GraphicsContext* gc, Mode mode, GLenum readBuffer, const std::string& name):
+                _gc(gc),
+                _mode(mode),
+                _readBuffer(readBuffer),
+                _fileName(name),
+                _pixelFormat(GL_BGRA),
+                _type(GL_UNSIGNED_BYTE),
+                _width(0),
+                _height(0),
+                _currentImageIndex(0),
+                _currentPboIndex(0),
+                _reportTimingFrequency(100),
+                _numTimeValuesRecorded(0),
+                _timeForReadPixels(0.0),
+                _timeForFullCopy(0.0),
+                _timeForMemCpy(0.0),
+                _image_available(false),
+                _currentImageToTransfer(NULL)
+            {
+                _previousFrameTick = osg::Timer::instance()->tick();
+
+                if (gc->getTraits())
+                {
+                    if (gc->getTraits()->alpha)
+                    {
+                        osg::notify(osg::NOTICE)<<"Select GL_RGBA read back format"<<std::endl;
+                        //_pixelFormat = GL_BGRA;
+                        _pixelFormat = GL_RGBA;
+                    }
+                    else
+                    {
+                        osg::notify(osg::NOTICE)<<"Select GL_RGB read back format"<<std::endl;
+                        //_pixelFormat = GL_BGR;
+                        _pixelFormat = GL_RGB;
+                    }
+                }
+
+                getSize(gc, _width, _height);
+
+                std::cout<<"Window size "<<_width<<", "<<_height<<std::endl;
+
+                // single buffered image
+                _imageBuffer.push_back(new osg::Image);
+
+                // double buffer PBO.
+                switch(_mode)
+                {
+                    case(READ_PIXELS):
+                        osg::notify(osg::NOTICE)<<"Reading window usig glReadPixels, with out PixelBufferObject."<<std::endl;
+                        break;
+                    case(SINGLE_PBO):
+                        osg::notify(osg::NOTICE)<<"Reading window usig glReadPixels, with a single PixelBufferObject."<<std::endl;
+                        _pboBuffer.push_back(0);
+                        break;
+                    case(DOUBLE_PBO):
+                        osg::notify(osg::NOTICE)<<"Reading window usig glReadPixels, with a double buffer PixelBufferObject."<<std::endl;
+                        _pboBuffer.push_back(0);
+                        _pboBuffer.push_back(0);
+                        break;
+                    case(TRIPLE_PBO):
+                        osg::notify(osg::NOTICE)<<"Reading window usig glReadPixels, with a triple buffer PixelBufferObject."<<std::endl;
+                        _pboBuffer.push_back(0);
+                        _pboBuffer.push_back(0);
+                        _pboBuffer.push_back(0);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            inline void getSize(osg::GraphicsContext* gc, int& width, int& height)
+            {
+                if (gc->getTraits())
+                {
+                    width = gc->getTraits()->width;
+                    height = gc->getTraits()->height;
+                }
+            }
+
+            void updateTimings(osg::Timer_t tick_start,
+                               osg::Timer_t tick_afterReadPixels,
+                               osg::Timer_t tick_afterMemCpy,
+                               unsigned int dataSize);
+
+            inline void read()
+            {
+            	osg::GLExtensions* ext = osg::GLExtensions::Get(_gc->getState()->getContextID(),true);
+
+                if (ext->isPBOSupported && !_pboBuffer.empty())
+                {
+                    if (_pboBuffer.size()==1)
+                    {
+                        singlePBO(ext);
+                    }
+                    else
+                    {
+                        multiPBO(ext);
+                    }
+                }
+                else
+                {
+                    readPixels();
+                }
+            }
+
+            void readPixels();
+
+            inline osg::Image* getImage(void)
+            {
+            	if( (!_imageBuffer.empty()) && (_currentImageToTransfer != NULL) && (_image_available==true) )
+            	{
+            		return _currentImageToTransfer;
+            	}
+            	return NULL;
+            }
+
+            void singlePBO(osg::GLExtensions* ext);
+
+            void multiPBO(osg::GLExtensions* ext);
+
+            typedef std::vector< osg::ref_ptr<osg::Image> >             ImageBuffer;
+            typedef std::vector< GLuint > PBOBuffer;
+
+            osg::GraphicsContext*   _gc;
+            Mode                    _mode;
+            GLenum                  _readBuffer;
+            std::string             _fileName;
+
+            GLenum                  _pixelFormat;
+            GLenum                  _type;
+            int                     _width;
+            int                     _height;
+
+            unsigned int            _currentImageIndex;
+            ImageBuffer             _imageBuffer;
+
+            unsigned int            _currentPboIndex;
+            PBOBuffer               _pboBuffer;
+
+            unsigned int            _reportTimingFrequency;
+            unsigned int            _numTimeValuesRecorded;
+            double                  _timeForReadPixels;
+            double                  _timeForFullCopy;
+            double                  _timeForMemCpy;
+            osg::Timer_t            _previousFrameTick;
+            bool					_image_available;
+            osg::Image*				_currentImageToTransfer;
+        };
+
+        inline WindowCaptureCallback(Mode mode, FramePosition position, GLenum readBuffer):
+            _mode(mode),
+            _position(position),
+            _readBuffer(readBuffer)
+        {
+        }
+
+        inline FramePosition getFramePosition() const { return _position; }
+
+        inline ContextData* createContextData(osg::GraphicsContext* gc) const
+        {
+            std::stringstream filename;
+            filename << "test_"<<_contextDataMap.size()<<".jpg";
+            return new ContextData(gc, _mode, _readBuffer, filename.str());
+        }
+
+        inline ContextData* getContextData(osg::GraphicsContext* gc) const
+        {
+            OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
+            osg::ref_ptr<ContextData>& data = _contextDataMap[gc];
+            if (!data) data = createContextData(gc);
+
+            return data.get();
+        }
+
+        inline virtual void operator () (osg::RenderInfo& renderInfo) const
+        {
+            //glReadBuffer(_readBuffer);
+            osg::GraphicsContext* gc = renderInfo.getState()->getGraphicsContext();
+            osg::ref_ptr<ContextData> cd = getContextData(gc);
+            cd->read();
+        }
+
+        inline virtual void operator() (const osg::Camera& camera) const
+        {
+        	//glReadBuffer(_readBuffer);
+        	const osg::GraphicsContext* gc = camera.getGraphicsContext();
+            osg::ref_ptr<ContextData> cd = getContextData(const_cast<osg::GraphicsContext*>(gc));
+            cd->read();
+        }
+
+        inline osg::Image* getImage(osg::GraphicsContext* graphicscontext)
+        {
+        	osg::ref_ptr<ContextData> cd = getContextData(graphicscontext);
+        	return cd->getImage();
+        }
+
+        typedef std::map<osg::GraphicsContext*, osg::ref_ptr<ContextData> > ContextDataMap;
+
+        Mode                        _mode;
+        FramePosition               _position;
+        GLenum                      _readBuffer;
+        mutable OpenThreads::Mutex  _mutex;
+        mutable ContextDataMap      _contextDataMap;
+
+
+};
+
+void addCallbackToViewer(osgViewer::ViewerBase& viewer, WindowCaptureCallback* callback);
+
+
+#endif /* SCREENVIEW_H_ */

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Array.java
@@ -1,0 +1,37 @@
+package org.openscenegraph.osg.core;
+
+public class Array {
+	private static native void nativeDispose(long cptr);
+	private static native int nativeSize(long cptr);
+
+	protected long _cptr;
+	
+	public Array() {
+		_cptr = 0;
+	}
+	
+	public Array(long cptr) {
+		_cptr = cptr;	
+	}
+
+	public long getNativePtr() {
+		return _cptr;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	public int size()
+	{
+		return nativeSize(_cptr);
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Array.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Array {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Camera.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Camera.java
@@ -26,7 +26,11 @@ public class Camera extends Group implements Native  {
 
 	private static native void nativeSetClearColor(long cptr, float r, float g,
 			float b, float a);
+	
+	private static native void nativeSetClearColorVec(long cptr, long vec_cptr);
 
+	private static native long nativeGetViewMatrix(long cptr);
+	
 	private static native void nativeSetViewMatrixAsLookAt(long cptr,
 			long eyecptr, long centercptr, long upcptr);
 
@@ -69,6 +73,16 @@ public class Camera extends Group implements Native  {
 
 	public void setClearColor(float r, float g, float b, float a) {
 		nativeSetClearColor(_cptr, r, g, b, a);
+	}
+	
+	public void setClearColor(Vec4 rgba)
+	{
+		nativeSetClearColorVec(_cptr, rgba.getNativePtr());
+	}
+
+	public Matrix getViewMatrix()
+	{
+		return new Matrix(nativeGetViewMatrix(_cptr));
 	}
 
 	public void setViewMatrixAsLookAt(Vec3 eye, Vec3 center, Vec3 up) {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawArrays.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawArrays.java
@@ -1,0 +1,28 @@
+package org.openscenegraph.osg.core;
+
+public class DrawArrays extends PrimitiveSet {
+	private static native void nativeDispose(long cptr);
+	private static native long nativeCreateDrawArrays(int mode, int first, int count);
+	
+	public DrawArrays(long cptr)
+	{
+		super(cptr);
+	}
+	
+	public DrawArrays(int mode, int first, int count)
+	{
+		_cptr = nativeCreateDrawArrays(mode, first, count);
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawArrays.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawArrays.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class DrawArrays extends PrimitiveSet {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawElementsUInt.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawElementsUInt.java
@@ -1,0 +1,40 @@
+package org.openscenegraph.osg.core;
+
+public class DrawElementsUInt extends PrimitiveSet {
+	private static native void nativeDispose(long cptr);
+	private static native long nativeCreateDrawElementsUInt(int mode, int count);
+	public static native int nativeSize(long cptr);
+	public static native void nativePushBackUInt(long cptr, int value);
+	
+	public DrawElementsUInt(long cptr)
+	{
+		super(cptr);
+	}
+	
+	public DrawElementsUInt(int mode, int count)
+	{
+		_cptr = nativeCreateDrawElementsUInt(mode, count);
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	public int size()
+	{
+		return nativeSize(_cptr);
+	}
+	
+	public void push_back(int index)
+	{
+		nativePushBackUInt(_cptr, index);
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawElementsUInt.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/DrawElementsUInt.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class DrawElementsUInt extends PrimitiveSet {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Drawable.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Drawable.java
@@ -1,0 +1,31 @@
+package org.openscenegraph.osg.core;
+
+public class Drawable {
+	private static native void nativeDispose(long cptr);
+
+	protected long _cptr;
+	
+	public Drawable() {
+		_cptr = 0;
+	}
+	
+	public Drawable(long cptr) {
+		_cptr = cptr;	
+	}
+
+	public long getNativePtr() {
+		return _cptr;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Drawable.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Drawable.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Drawable {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geode.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geode.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Geode extends Node {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geode.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geode.java
@@ -1,0 +1,69 @@
+package org.openscenegraph.osg.core;
+
+public class Geode extends Node {
+	
+	private static native long nativeCreateGeode();
+	private static native void nativeDispose(long cptr);
+	private static native boolean nativeAddDrawable(long cptr, long drawable_ptr);
+	private static native boolean nativeRemoveDrawable(long cptr, long cptr_drawable);
+	private static native boolean nativeRemoveDrawables(long cptr, int i, int m);
+	private static native boolean nativeReplaceDrawable(long cptr, long cptr_drawable_old, long cptr_drawable_new);
+	private static native boolean nativeSetDrawable(long cptr, int i, long cptr_drawable);
+	private static native int nativeGetNumDrawables(long cptr);
+	private static native long nativeGetDrawable(long cptr, int i);
+
+	public Geode() {
+		_cptr = nativeCreateGeode();
+	}
+
+	public Geode(long cptr) {
+		super(cptr);
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+
+	public boolean addDrawable(Drawable _drawable)
+	{
+		return nativeAddDrawable(_cptr, _drawable.getNativePtr());
+	}
+	
+	public boolean removeDrawable(Drawable _drawable)
+	{
+		return nativeRemoveDrawable(_cptr, _drawable.getNativePtr());
+	}
+	
+	public boolean removeDrawables(int index, int numElements)
+	{
+		return nativeRemoveDrawables(_cptr, index, numElements);
+	}
+	
+	public boolean replaceDrawable(Drawable old_element, Drawable new_element)
+	{
+		return nativeReplaceDrawable(_cptr, old_element.getNativePtr(), new_element.getNativePtr());
+	}
+	
+	public boolean setDrawable(int index, Drawable _drawable)
+	{
+		return nativeSetDrawable(_cptr, index, _drawable.getNativePtr());
+	}
+	
+	public int getNumDrawables()
+	{
+		return nativeGetNumDrawables(_cptr);
+	}
+	
+	public Drawable getDrawable(int index)
+	{
+		return new Drawable(nativeGetDrawable(_cptr, index));
+	}
+	
+	public Drawable getLastDrawable()
+	{
+		int pos = getNumDrawables()-1;
+		return new Drawable(nativeGetDrawable(_cptr, pos));
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geometry.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geometry.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 import android.util.Log;

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geometry.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Geometry.java
@@ -1,0 +1,155 @@
+package org.openscenegraph.osg.core;
+
+import android.util.Log;
+
+
+public class Geometry extends Drawable {
+	public static final int BIND_OFF = 0;
+	public static final int BIND_OVERALL = 1;
+	public static final int BIND_PER_PRIMITIVE_SET = 2;
+	public static final int BIND_PER_VERTEX = 4;
+	
+	private static native long nativeCreateGeometry();
+	private static native void nativeDispose(long cptr);
+	private static native void nativeSetVertexArray(long cptr, float[][] inputBuffer);
+	private static native void nativeSetVertexArrayNative(long cptr, long array_cptr);
+	private static native long nativeGetVertexArray(long cptr);
+	private static native void nativeSetColorArray(long cptr, float[][] inputBuffer);
+	private static native void nativeSetColorArrayNative(long cptr, long array_cptr);
+	private static native long nativeGetColorArray(long cptr);
+	private static native void nativeSetNormalArray(long cptr, float[][] inputBuffer);
+	private static native void nativeSetNormalArrayNative(long cptr, long array_cptr);
+	private static native long nativeGetNormalArray(long cptr);
+	private static native void nativeSetTexCoordArray(long cptr, float[][] inputBuffer, int tex_unit);
+	private static native void nativeSetTexCoordArrayNative(long cptr, long array_cptr, int tex_unit);
+	private static native long nativeGetTexCoordArray(long cptr, int tex_unit);
+	private static native void nativeSetColorBinding(long cptr, int binding);
+	private static native void nativeSetNormalBinding(long cptr, int binding);
+	private static native boolean nativeAddPrimitiveSet(long cptr, long set_cptr);
+	private static native void nativeSetPrimitiveSetList(long cptr, long list_cptr);
+	private static native boolean nativeTextureFromPosePoint(long cptr, int i, long Cg_ptr, long trmat_ptr, long R_ptr, long img_ptr);
+	private static native int nativeTextureFromPose(long cptr, long Cg_ptr, long trmat_ptr, long R_ptr, long img_ptr);
+	
+	public Geometry(long cptr) {
+		super(cptr);	
+	}
+	
+	@Override
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+		//Log.w("org.openscenegraph.osg.core.Geometry", "Object destroyed");
+	}
+	
+	public Geometry() {
+		_cptr = nativeCreateGeometry();
+	}
+	
+	public void setVertexArray(float array[][])
+	{
+		nativeSetVertexArray(_cptr, array);
+	}
+
+	public void setColorArray(float array[][])
+	{
+		nativeSetColorArray(_cptr, array);
+	}
+	
+	public void setNormalArray(float array[][])
+	{
+		nativeSetNormalArray(_cptr, array);
+	}
+
+	public void setTexCoordArray(int unit, float array[][])
+	{
+		nativeSetTexCoordArray(_cptr, array, unit);
+	}
+	
+	public void setVertexArray(Vec3Array vertices)
+	{
+		nativeSetVertexArrayNative(_cptr, vertices.getNativePtr());
+	}
+	
+	public Vec3Array getVertexArray()
+	{
+		return new Vec3Array(nativeGetVertexArray(_cptr));
+	}
+
+	public void setColorArray(Vec4Array colors)
+	{
+		nativeSetColorArrayNative(_cptr, colors.getNativePtr());
+	}
+	
+	public Vec4Array getColorArray()
+	{
+		return new Vec4Array(nativeGetColorArray(_cptr));
+	}
+	
+	public void setNormalArray(Vec3Array normal)
+	{
+		nativeSetNormalArrayNative(_cptr, normal.getNativePtr());
+	}
+	
+	public Vec3Array getNormalArray()
+	{
+		return new Vec3Array(nativeGetNormalArray(_cptr));
+	}
+
+	public void setTexCoordArray(int unit, Vec2Array tex_coords)
+	{
+		nativeSetTexCoordArrayNative(_cptr, tex_coords.getNativePtr(), unit);
+	}
+	
+	public Vec2Array getTexCoordArray(int unit)
+	{
+		return new Vec2Array(nativeGetTexCoordArray(_cptr, unit));
+	}
+	
+	public void setNormalBinding(int _binding)
+	{
+		nativeSetNormalBinding(_cptr, _binding);
+	}
+	
+	public void setColorBinding(int binding)
+	{
+		nativeSetColorBinding(_cptr, binding);
+	}
+	
+	public void setPrimitiveSetList(PrimitiveSetList list)
+	{
+		nativeSetPrimitiveSetList(_cptr, list.getNativePtr());
+	}
+	
+	public boolean addPrimitiveSet(PrimitiveSet primitiveset) {
+		return nativeAddPrimitiveSet(_cptr, primitiveset.getNativePtr());
+	}
+	
+	public int TextureFromPose(Vec3 Cg, Matrix trmat, Vec3 RvecCam, Image img)
+	{
+		if(img==null)
+		{
+			Log.e("org.openscenegraph.osg.core.Geometry", "Texture from Pose: image input is null - ABORT.");
+			return 0;
+		}
+		
+		return nativeTextureFromPose(_cptr, Cg.getNativePtr(), trmat.getNativePtr(), RvecCam.getNativePtr(), img.getNativePtr());
+	}
+	
+	public boolean TextureFromPosePoint(int index, Vec3 Cg, Matrix trmat, Vec3 RvecCam, Image img)
+	{
+		if(img==null)
+		{
+			Log.e("org.openscenegraph.osg.core.Geometry", "Texture from Pose: image input is null - ABORT.");
+			return false;
+		}
+		
+		return nativeTextureFromPosePoint(_cptr, index, Cg.getNativePtr(), trmat.getNativePtr(), RvecCam.getNativePtr(), img.getNativePtr());
+	}	
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Group.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Group.java
@@ -26,6 +26,7 @@ public class Group extends Node {
 	private static native boolean nativeAddChild(long cptr, long node);
 	private static native boolean nativeRemoveChild(long cptr, long node);
 	private static native int nativeGetNumChildren(long cptr);
+	private static native long nativeGetChild(long cptr, int i);
 	
 	public Group(long cptr) {
 		super(cptr);	
@@ -51,5 +52,15 @@ public class Group extends Node {
 	
 	public int getNumChildren() {
 		return nativeGetNumChildren(_cptr);
+	}
+	
+	public Node getChild(int index)
+	{
+		return new Node(nativeGetChild(_cptr, index));
+	}
+	
+	public Node getLastChild()
+	{
+		return new Node(nativeGetChild(_cptr, getNumChildren()-1));
 	}
 }

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Image.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Image.java
@@ -18,6 +18,9 @@
  ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
+import android.graphics.Bitmap;
+import android.graphics.Color;
+
 
 public class Image extends Node {
 
@@ -32,6 +35,12 @@ public class Image extends Node {
             byte [] data);
 
 	private static native void nativeDirty(long cptr);
+	private static native int nativeS(long cptr);
+	private static native int nativeT(long cptr);
+	private static native byte nativeGetRed(long cptr, int s, int t, int r);
+	private static native byte nativeGetGreen(long cptr, int s, int t, int r);
+	private static native byte nativeGetBlue(long cptr, int s, int t, int r);
+	private static native byte nativeGetAlpha(long cptr, int s, int t, int r);
 
 	public Image(long cptr) {
 		super(cptr);
@@ -61,5 +70,42 @@ public class Image extends Node {
 	public void dirty() {
 		nativeDirty(getNativePtr());
 	}
+	
+	public int s()
+	{
+		return nativeS(_cptr);
+	}
+	
+	public int t()
+	{
+		return nativeT(_cptr);
+	}
 
+	public byte getRed(int s, int t, int r)
+	{
+		return nativeGetRed(_cptr, s, t, r);
+	}
+	
+	public byte getGreen(int s, int t, int r)
+	{
+		return nativeGetGreen(_cptr, s, t, r);
+	}
+	
+	public byte getBlue(int s, int t, int r)
+	{
+		return nativeGetBlue(_cptr, s, t, r);
+	}
+	
+	public Bitmap toBitmap()
+	{
+		Bitmap result = Bitmap.createBitmap(s(), t(), Bitmap.Config.ARGB_8888);
+		for(int x = 0; x < s(); x++)
+		{
+			for(int y = 0; y < t(); y++)
+			{
+				result.setPixel(x, y, Color.argb(255, Integer.valueOf(getRed(x, y, 0)), Integer.valueOf(getGreen(x, y, 0)), Integer.valueOf(getBlue(x, y, 0))));
+			}
+		}
+		return result;
+	}
 }

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Matrix.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Matrix.java
@@ -26,11 +26,23 @@ public class Matrix implements Native {
 
 	private static native void nativeDispose(long cptr);
 
+	private static native long nativeInverse(long cptr);
+	
+	private static native long nativeTranspose(long cptr);
+	
+	private static native long nativeScale(long vec_cptr);
+	
 	private static native void nativeSet(long cptr, float a00, float a01,
 			float a02, float a03, float a10, float a11, float a12, float a13,
 			float a20, float a21, float a22, float a23, float a30, float a31,
 			float a32, float a33);
+	
+	private static native float nativeGet(long cptr, int row, int column);
 
+	private static native long nativeGetTranslation(long cptr);
+	
+	private static native long nativeGetRotation(long cptr);
+	
 	private static native boolean nativeIsIdentity(long cptr);
 
 	private static native void nativeMakeIdentity(long cptr);
@@ -51,6 +63,8 @@ public class Matrix implements Native {
 	private static native void nativePreMult(long cptr, long matrix);
 
 	private static native void nativePostMult(long cptr, long matrix);
+	
+	private static native void nativeMult(long cptr, long m1_ptr, long m2_ptr);
 	
 	private static native void nativeMakeLookAt(long cptr, long eye, long center, long up);
 
@@ -79,7 +93,34 @@ public class Matrix implements Native {
 	public Matrix() {
 		_cptr = nativeCreateMatrix();
 	}
+	
+	public static Matrix inverse(Matrix m)
+	{
+		return new Matrix(nativeInverse(m.getNativePtr()));
+	}
+	
+	public static Matrix transpose(Matrix m)
+	{
+		return new Matrix(nativeTranspose(m.getNativePtr()));
+	}
+	
+	public static Matrix scale(Vec3 scale_values)
+	{
+		return new Matrix(nativeScale(scale_values.getNativePtr()));
+	}
+	
+	public Matrix clone()
+	{
+		Matrix result = new Matrix();
+		result.set(get(0,0),get(0,1),get(0,2),get(0,3), get(1,0),get(1,1),get(1,2),get(1,3), get(2,0),get(2,1),get(2,2),get(2,3), get(3,0),get(3,1),get(3,2),get(3,3));
+		return result;
+	}
 
+	public float get(int row, int column)
+	{
+		return nativeGet(_cptr, row, column);
+	}
+	
 	public Matrix(float a00, float a01, float a02, float a03, float a10,
 			float a11, float a12, float a13, float a20, float a21, float a22,
 			float a23, float a30, float a31, float a32, float a33) {
@@ -104,6 +145,16 @@ public class Matrix implements Native {
 		return nativeIsIdentity(_cptr);
 	}
 
+	public Matrix getTranslation()
+	{
+		return new Matrix(nativeGetTranslation(_cptr));
+	}
+	
+	public Matrix getRotation()
+	{
+		return new Matrix(nativeGetRotation(_cptr));
+	}
+	
 	public void makeIdentity() {
 		nativeMakeIdentity(_cptr);
 	}
@@ -136,7 +187,50 @@ public class Matrix implements Native {
 		nativePostMult(_cptr, matrix.getNativePtr());
 	}
 	
+	public void mult(Matrix m1, Matrix m2)
+	{
+		nativeMult(_cptr, m1.getNativePtr(), m2.getNativePtr());
+	}
+	
 	public void makeLookAt(Vec3 eye, Vec3 center, Vec3 up) {
 		nativeMakeLookAt(_cptr, eye.getNativePtr(), center.getNativePtr(), up.getNativePtr());
+	}
+	
+	@Override
+	public String toString()
+	{
+		String output = "";
+		output+="[";
+		
+		output+="[";
+		output+=Float.toString(get(0,0))+",";
+		output+=Float.toString(get(0,1))+",";
+		output+=Float.toString(get(0,2))+",";
+		output+=Float.toString(get(0,3));
+		output+="]";
+		
+		output+="[";
+		output+=Float.toString(get(1,0))+",";
+		output+=Float.toString(get(1,1))+",";
+		output+=Float.toString(get(1,2))+",";
+		output+=Float.toString(get(1,3));
+		output+="]";
+		
+		output+="[";
+		output+=Float.toString(get(2,0))+",";
+		output+=Float.toString(get(2,1))+",";
+		output+=Float.toString(get(2,2))+",";
+		output+=Float.toString(get(2,3));
+		output+="]";
+		
+		output+="[";
+		output+=Float.toString(get(3,0))+",";
+		output+=Float.toString(get(3,1))+",";
+		output+=Float.toString(get(3,2))+",";
+		output+=Float.toString(get(3,3));
+		output+="]";
+		
+		output+="]";
+		return output;
 	}
 }

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Node.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Node.java
@@ -25,7 +25,10 @@ public class Node implements Native {
 	private static native void nativeSetUpdateCallback(long cptr, long ucb);
 	private static native void nativeSetRenderBinDetails(long cptr, int order, String bin);
 	private static native void nativeSetTexture2D(long cptr, long cptrimage);
+	private static native void nativeSetTexture(long cptr, long texture_cptr, int tex_unit);
 	private static native void nativeSetMode(long cptr, int mode, int value);
+	private static native void nativeSetPointSize(long cptr, float pt_size);
+	private static native void nativeSetLineWidth(long cptr, float line_size);
 	
     public static class Values
     {   
@@ -78,6 +81,12 @@ public class Node implements Native {
 	public void setTexture2D(Image image) {
 		nativeSetTexture2D(_cptr,image.getNativePtr());
 	}
+	
+	public void setTexture(Texture texture, int texture_unit)
+	{
+		nativeSetTexture(_cptr, texture.getNativePtr(), texture_unit);
+	}
+	
 	/** 
 	 * Sets the stateset mode to the value
 	 * @param mode GLenum mode values (GL_LIGHTING, GL_TEXTURE, GL_DEPTH_TEST, ...etc)
@@ -86,5 +95,19 @@ public class Node implements Native {
 	public void setMode(int mode, int value) {
 		nativeSetMode(_cptr,mode,value);
 	}
+	
+	public void setPointSize(float pointsize)
+	{
+		nativeSetPointSize(_cptr, pointsize);
+	}
 
+	public void setLineWidth(float width)
+	{
+		nativeSetLineWidth(_cptr, width);
+	}
+	
+	public long asNode()
+	{
+		return _cptr;
+	}
 }

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Object.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Object.java
@@ -1,0 +1,50 @@
+package org.openscenegraph.osg.core;
+
+public class Object {
+	private static native void nativeDispose(long cptr);
+	private static native void nativeSetDataVariance(long cptr, int dv);
+	private static native int nativeGetDataVariance(long cptr);
+
+    public static class DataVariance
+    {   
+        public static final int DYNAMIC      = 0x0;
+        public static final int STATIC       = 0x1;
+        public static final int UNSPECIFIED  = 0x2;
+    };
+
+	protected long _cptr;
+	
+	public Object() {
+		_cptr = 0;
+	}
+	
+	public Object(long cptr) {
+		_cptr = cptr;	
+	}
+
+	public long getNativePtr() {
+		return _cptr;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	public void setDataVariance(int dv)
+	{
+		nativeSetDataVariance(_cptr, dv);
+	}
+	
+	public int getDataVariance()
+	{
+		return nativeGetDataVariance(_cptr);
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Object.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Object.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Object {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSet.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSet.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 import android.opengl.GLES11;
 

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSet.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSet.java
@@ -1,0 +1,50 @@
+package org.openscenegraph.osg.core;
+import android.opengl.GLES11;
+
+public class PrimitiveSet {
+	public static final int PrimitiveType = 0;
+	public static final int DrawArraysPrimitiveType = 1;
+	public static final int DrawArrayLengthsPrimitiveType = 2;
+	public static final int DrawElementsUBytePrimitiveType = 3;
+	public static final int DrawElementsUShortPrimitiveType = 4;
+	public static final int DrawElementsUIntPrimitiveType = 5;
+	
+	public static final int POINTS = GLES11.GL_POINTS;
+	public static final int LINES = GLES11.GL_LINES;
+	public static final int LINE_STRIP = GLES11.GL_LINE_STRIP;
+	public static final int LINE_LOOP = GLES11.GL_LINE_LOOP;
+	public static final int TRIANGLES = GLES11.GL_TRIANGLES;
+	public static final int TRIANGLE_STRIP = GLES11.GL_TRIANGLE_STRIP;
+	public static final int TRIANGLE_FAN = GLES11.GL_TRIANGLE_FAN;
+	
+	private static native long nativeCreatePrimitiveSet(int type, int mode);
+	private static native void nativeDispose(long cptr);
+	
+	protected long _cptr;
+	
+	public long getNativePtr() {
+		return _cptr;
+	}
+	
+	public PrimitiveSet()
+	{
+		_cptr = 0;
+	}
+	
+	public PrimitiveSet(long cptr) {
+		_cptr = cptr;
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSetList.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSetList.java
@@ -1,0 +1,44 @@
+package org.openscenegraph.osg.core;
+
+public class PrimitiveSetList {
+	public static native void nativeDispose(long cptr);
+	public static native long nativeCreatePrimitiveSetList();
+	public static native int nativeSize(long cptr);
+	public static native void nativePushBackPrimitiveSet(long cptr, long object_cptr);
+	
+	protected long _cptr;
+	
+	public PrimitiveSetList() {
+		_cptr = nativeCreatePrimitiveSetList();
+	}
+	
+	public PrimitiveSetList(long cptr) {
+		_cptr = cptr;	
+	}
+
+	public long getNativePtr() {
+		return _cptr;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	public int size()
+	{
+		return nativeSize(_cptr);
+	}
+	
+	public void push_back(PrimitiveSet set)
+	{
+		nativePushBackPrimitiveSet(_cptr, set.getNativePtr());
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSetList.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/PrimitiveSetList.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class PrimitiveSetList {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Texture extends Object {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture.java
@@ -1,0 +1,46 @@
+package org.openscenegraph.osg.core;
+
+public class Texture extends Object {
+	private static native void nativeDispose(long cptr);
+	private static native void nativeSetImage(long cptr, int face, long image_cptr);
+	private static native long nativeGetImage(long cptr, int face);
+	
+	public Texture(long cptr)
+	{
+		super(cptr);
+	}
+	
+	@Override
+	public void dispose()
+	{
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public void setImage(int face, Image image)
+	{
+		nativeSetImage(_cptr, face, image.getNativePtr());
+	}
+	
+	public Image getImage(int face)
+	{
+		long image_ptr = nativeGetImage(_cptr, face);
+		Image result;
+		if(image_ptr != 0)
+		{
+			result = new Image(image_ptr);
+		}
+		else
+		{
+			result = new Image();
+		}
+		return result;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture2D.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture2D.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Texture2D extends Texture {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture2D.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Texture2D.java
@@ -1,0 +1,74 @@
+package org.openscenegraph.osg.core;
+
+public class Texture2D extends Texture {
+	private static native void nativeDispose(long cptr);
+	private static native long nativeCreateTexture2D();
+	private static native void nativeSetImage(long cptr, long image_cptr);
+	private static native long nativeGetImage(long cptr);
+	
+	public Texture2D(long cptr)
+	{
+		super(cptr);
+	}
+	
+	public Texture2D()
+	{
+		super( nativeCreateTexture2D() );
+	}
+	
+	@Override
+	public void dispose()
+	{
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	@Override
+	public void setImage(int face, Image image)
+	{
+		nativeSetImage(_cptr, image.getNativePtr());
+	}
+
+	public void setImage(Image image)
+	{
+		nativeSetImage(_cptr, image.getNativePtr());
+	}
+	
+	@Override
+	public Image getImage(int face)
+	{
+		long image_ptr = nativeGetImage(_cptr);
+		Image result;
+		if(image_ptr != 0)
+		{
+			result = new Image(image_ptr);
+		}
+		else
+		{
+			result = new Image();
+		}
+		return result;
+	}
+
+	public Image getImage()
+	{
+		long image_ptr = nativeGetImage(_cptr);
+		Image result;
+		if(image_ptr != 0)
+		{
+			result = new Image(image_ptr);
+		}
+		else
+		{
+			result = new Image();
+		}
+		return result;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 import org.openscenegraph.osg.Native;

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2.java
@@ -1,0 +1,137 @@
+package org.openscenegraph.osg.core;
+
+import org.openscenegraph.osg.Native;
+
+public class Vec2 implements Native {
+
+	private static native long nativeCreateVec2();
+	private static native void nativeDispose(long cptr);
+	private static native float nativeX(long cptr);
+	private static native float nativeY(long cptr);
+	private static native void nativeSet(long cptr, float x, float y);
+	private static native void nativeSetX(long cptr, float value);
+	private static native void nativeSetY(long cptr, float value);
+	private static native float nativeLength(long cptr);
+	private static native float nativeLength2(long cptr);
+	private static native long nativeDiv(long cptr, float value);
+	private static native float nativeDotProduct(long cptr, long rhs);
+	private static native long nativeCrossProduct(long cptr, long rhs);
+	private static native long nativeEscalarProduct(long cptr, float value);
+	private static native long nativeSum(long cptr, long rhs);
+	private static native long nativeSub(long cptr, long rhs);
+	private static native float nativeNormalize(long cptr);
+	private static native long nativeNegation(long cptr);
+	
+	private long _cptr;
+	public long getNativePtr() {
+		return _cptr;
+	}
+	
+	public Vec2(long cptr) {
+		_cptr = cptr;	
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+
+	public void dispose() {
+		if(_cptr != 0)
+			nativeDispose(_cptr);
+		_cptr = 0;
+	}
+	
+	public Vec2() {
+		_cptr = nativeCreateVec2();	
+	}
+	
+	public Vec2(float x, float y) {
+		_cptr = nativeCreateVec2();
+		set(x,y);
+	}
+	
+	public float x() {
+		return nativeX(_cptr);
+	}
+	
+	public float y() {
+		return nativeY(_cptr);
+	}
+	
+	public void set(float x, float y) {
+		nativeSet(_cptr, x, y);
+	}
+	
+	public void set(Vec2 v) {
+		set(v.x(),v.y());
+	}
+	
+	public void setX(float value) {
+		nativeSetX(_cptr,value);
+	}
+
+	public void setY(float value) {
+		nativeSetY(_cptr,value);
+	}
+
+	public String toString() {
+		return "(" + x() + "," + y() + ")";
+	}
+
+	public float length() {
+		return nativeLength(_cptr);
+	}
+
+	public float length2() {
+		return nativeLength2(_cptr);
+	}
+
+	/** Divide by scalar. */
+	public Vec2 div(float value) {
+		return new Vec2(nativeDiv(_cptr,value));
+	}
+
+	/** Dot product. */
+	public float dotProduct(Vec2 rhs) {
+		return nativeDotProduct(_cptr,rhs.getNativePtr());
+	}
+
+	/** Multiply by scalar. */
+	public Vec2 escalarProduct(float rhs) {
+		return new Vec2(nativeEscalarProduct(_cptr,rhs));
+	}
+
+	/** Binary vector add. */
+	public Vec2 sum(Vec2 rhs) {
+		return new Vec2(nativeSum(_cptr,rhs.getNativePtr()));
+	}
+
+	/** Binary vector subtract. */
+	public Vec2 sub(Vec2 rhs) {
+		return new Vec2(nativeSub(_cptr,rhs.getNativePtr()));
+
+	}
+
+	/** normalization of the vector. */
+	public float normalize() {
+		return nativeNormalize(_cptr);
+	}
+
+	/** Negation operator. Returns the negative of the Vec3d. */
+
+	public Vec2 negation() {
+		return new Vec2(nativeNegation(_cptr));
+	}
+	
+	@Override
+	public boolean equals(java.lang.Object obj) {
+
+		Vec2 in = (Vec2) obj;
+		
+		if(in.x()==x() && in.y()==y()) return true;
+		return super.equals(obj);
+	
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2Array.java
@@ -1,0 +1,79 @@
+package org.openscenegraph.osg.core;
+
+public class Vec2Array extends Array {
+	private static native void nativeDispose(long cptr);
+	private static native long nativeCreateVec2Array();
+	private static native void nativePushBackVec2(long cptr, long vec_cptr);
+	private static native void nativePushBackFloatArray(long cptr, float[] array_cptr);
+	private static native long nativePopBack(long cptr);
+	private static native long nativeGet(long cptr, int i);
+	private static native boolean nativeSet(long cptr, int i, long vec_cptr);
+	
+	public Vec2Array(long cptr) {
+		super(cptr);	
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public Vec2Array() {
+		_cptr = nativeCreateVec2Array();
+	}
+	
+	protected void push_back(float[] array)
+	{
+		nativePushBackFloatArray(_cptr, array);
+	}
+	
+	protected void push_back(Vec2 vector)
+	{
+		nativePushBackVec2(_cptr, vector.getNativePtr());
+	}
+
+	public void add(float[] value)
+	{
+		push_back(value);
+	}
+	
+	public void add(Vec2 value)
+	{
+		push_back(value);
+	}
+	
+	protected Vec2 pop_back()
+	{
+		return new Vec2(nativePopBack(_cptr));
+	}
+	
+	public Vec2 get(int i)
+	{
+		return new Vec2(nativeGet(_cptr, i));
+	}
+	
+	public boolean set(int i, Vec2 v)
+	{
+		return nativeSet(_cptr, i, v.getNativePtr());
+	}
+	
+	/*
+	 * the "toArray" function replaces the vector array with the
+	 * float array, thus the original vector array is empty after
+	 * this operation.
+	 */
+	public float[][] toArray()
+	{
+		int N = size();
+		int n = N-1;
+		float buffer[][] = new float[N][2];
+		for(int i = 0; i < N; i++)
+		{
+			Vec2 vec = pop_back();
+			buffer[n-i][0] = vec.x();
+			buffer[n-i][1] = vec.y();
+		}
+		return buffer;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec2Array.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Vec2Array extends Array {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec3.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec3.java
@@ -159,7 +159,7 @@ public class Vec3 implements Native {
 	}
 	
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(java.lang.Object obj) {
 
 		Vec3 in = (Vec3) obj;
 		

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec3Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec3Array.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Vec3Array extends Array {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec3Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec3Array.java
@@ -1,0 +1,80 @@
+package org.openscenegraph.osg.core;
+
+public class Vec3Array extends Array {
+	private static native void nativeDispose(long cptr);
+	private static native long nativeCreateVec3Array();
+	private static native void nativePushBackVec3(long cptr, long vec_cptr);
+	private static native void nativePushBackFloatArray(long cptr, float[] array_cptr);
+	private static native long nativePopBack(long cptr);
+	private static native long nativeGet(long cptr, int i);
+	private static native boolean nativeSet(long cptr, int i, long vec_cptr);
+	
+	public Vec3Array(long cptr) {
+		super(cptr);	
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public Vec3Array() {
+		_cptr = nativeCreateVec3Array();
+	}
+	
+	protected void push_back(float[] array)
+	{
+		nativePushBackFloatArray(_cptr, array);
+	}
+	
+	protected void push_back(Vec3 vector)
+	{
+		nativePushBackVec3(_cptr, vector.getNativePtr());
+	}
+
+	public void add(float[] value)
+	{
+		push_back(value);
+	}
+	
+	public void add(Vec3 value)
+	{
+		push_back(value);
+	}
+	
+	protected Vec3 pop_back()
+	{
+		return new Vec3(nativePopBack(_cptr));
+	}
+	
+	public Vec3 get(int i)
+	{
+		return new Vec3(nativeGet(_cptr, i));
+	}
+	
+	public boolean set(int i, Vec3 v)
+	{
+		return nativeSet(_cptr, i, v.getNativePtr());
+	}
+	
+	/*
+	 * the "toArray" function replaces the vector array with the
+	 * float array, thus the original vector array is empty after
+	 * this operation.
+	 */
+	public float[][] toArray()
+	{
+		int N = size();
+		int n = N-1;
+		float buffer[][] = new float[N][3];
+		for(int i = 0; i < N; i++)
+		{
+			Vec3 vec = pop_back();
+			buffer[n-i][0] = vec.x();
+			buffer[n-i][1] = vec.y();
+			buffer[n-i][2] = vec.z();
+		}
+		return buffer;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec4.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec4.java
@@ -157,7 +157,7 @@ public class Vec4 implements Native {
 	}
 	
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(java.lang.Object obj) {
 
 		Vec4 in = (Vec4) obj;
 		

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec4Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec4Array.java
@@ -1,0 +1,81 @@
+package org.openscenegraph.osg.core;
+
+public class Vec4Array extends Array {
+	private static native void nativeDispose(long cptr);
+	private static native long nativeCreateVec4Array();
+	private static native void nativePushBackVec4(long cptr, long vec_cptr);
+	private static native void nativePushBackFloatArray(long cptr, float[] array_cptr);
+	private static native long nativePopBack(long cptr);
+	private static native long nativeGet(long cptr, int i);
+	private static native boolean nativeSet(long cptr, int i, long vec_cptr);
+	
+	public Vec4Array(long cptr) {
+		super(cptr);	
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		dispose();
+		super.finalize();
+	}
+	
+	public Vec4Array() {
+		_cptr = nativeCreateVec4Array();
+	}
+	
+	protected void push_back(float[] array)
+	{
+		nativePushBackFloatArray(_cptr, array);
+	}
+	
+	protected void push_back(Vec4 vector)
+	{
+		nativePushBackVec4(_cptr, vector.getNativePtr());
+	}
+
+	public void add(float[] value)
+	{
+		push_back(value);
+	}
+	
+	public void add(Vec4 value)
+	{
+		push_back(value);
+	}
+	
+	protected Vec4 pop_back()
+	{
+		return new Vec4(nativePopBack(_cptr));
+	}
+	
+	public Vec4 get(int i)
+	{
+		return new Vec4(nativeGet(_cptr, i));
+	}
+	
+	public boolean set(int i, Vec4 v)
+	{
+		return nativeSet(_cptr, i, v.getNativePtr());
+	}
+	
+	/*
+	 * the "toArray" function replaces the vector array with the
+	 * float array, thus the original vector array is empty after
+	 * this operation.
+	 */
+	public float[][] toArray()
+	{
+		int N = size();
+		int n = N-1;
+		float buffer[][] = new float[N][4];
+		for(int i = 0; i < N; i++)
+		{
+			Vec4 vec = pop_back();
+			buffer[n-i][0] = vec.x();
+			buffer[n-i][1] = vec.y();
+			buffer[n-i][2] = vec.z();
+			buffer[n-i][3] = vec.w();
+		}
+		return buffer;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec4Array.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/core/Vec4Array.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.core;
 
 public class Vec4Array extends Array {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/db/ReadFile.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/db/ReadFile.java
@@ -19,9 +19,11 @@
 package org.openscenegraph.osg.db;
 
 import org.openscenegraph.osg.core.Node;
+import org.openscenegraph.osg.core.Image;
 
 public class ReadFile {
 	private static native long nativeReadNodeFile(String filename);
+	private static native long nativeReadImageFile(String filename);
 	
 	public static Node readNodeFile(String filename) {
 		long cptr = nativeReadNodeFile(filename);
@@ -30,4 +32,10 @@ public class ReadFile {
 		return new Node(cptr);
 	}
 
+	public static Image readImageFile(String filename) {
+		long cptr = nativeReadImageFile(filename);
+		if(cptr == 0)
+			return null;
+		return new Image(cptr);
+	}
 }

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/db/WriteFile.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/db/WriteFile.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.db;
 
 import org.openscenegraph.osg.core.Image;

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/db/WriteFile.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/db/WriteFile.java
@@ -1,0 +1,29 @@
+package org.openscenegraph.osg.db;
+
+import org.openscenegraph.osg.core.Image;
+import org.openscenegraph.osg.core.Node;
+
+public class WriteFile {
+	private static native boolean nativeWriteNodeFile(String filename, long node_cptr);
+	private static native boolean nativeWriteImageFile(String filename, long image_cptr);
+	
+	public static boolean writeNodeFile(String filename, Node node)
+	{
+		boolean result = false;
+		if(node.getNativePtr()!=0)
+			result = nativeWriteNodeFile(filename, node.getNativePtr());
+		else
+			result = false;
+		return result;
+	}
+
+	public static boolean writeImageFile(String filename, Image image)
+	{
+		boolean result = false;
+		if(image.getNativePtr()!=0)
+			result = nativeWriteNodeFile(filename, image.getNativePtr());
+		else
+			result = false;
+		return result;
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/util/GeometryUtils.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/util/GeometryUtils.java
@@ -19,15 +19,38 @@
 package org.openscenegraph.osg.util;
 
 import org.openscenegraph.osg.core.Camera;
+import org.openscenegraph.osg.core.Image;
+import org.openscenegraph.osg.core.Matrix;
+import org.openscenegraph.osg.core.Vec3;
+
+import android.util.Log;
 
 public class GeometryUtils {
 	private static native long nativeCreateScreenQuad(int x, int y, int w, int h, boolean isBackGround);
+	private static native int nativeTextureFromPose(String in_filepath, String out_filepath, long Cg_ptr, long trmat_ptr, long R_ptr, long img_ptr);
+	private static native int nativeTextureFromPoseImgfile(String in_filepath, String out_filepath, long Cg_ptr, long trmat_ptr, long R_ptr, String img_filename);
 	
 	public static Camera createScreenQuad(int x, int y, int w, int h, boolean isBackGround) {
 		long cptr = nativeCreateScreenQuad(x,y,w,h,isBackGround);
 		if(cptr == 0)
 			return null;
 		return new Camera(cptr);
+	}
+
+	public static int TextureFromPose(String in_geometryfile, String out_geometryfile, Vec3 Cg, Matrix trmat, Vec3 RvecCam, Image img)
+	{
+		if(img==null)
+		{
+			Log.e("org.openscenegraph.osg.core.Geometry", "Texture from Pose: image input is null - ABORT.");
+			return 0;
+		}
+		
+		return nativeTextureFromPose(in_geometryfile, out_geometryfile, Cg.getNativePtr(), trmat.getNativePtr(), RvecCam.getNativePtr(), img.getNativePtr());
+	}
+
+	public static int TextureFromPose(String in_geometryfile, String out_geometryfile, Vec3 Cg, Matrix trmat, Vec3 RvecCam, String img_filepath)
+	{
+		return nativeTextureFromPoseImgfile(in_geometryfile, out_geometryfile, Cg.getNativePtr(), trmat.getNativePtr(), RvecCam.getNativePtr(), img_filepath);
 	}
 
 }

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/OSGRenderer.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/OSGRenderer.java
@@ -1,6 +1,6 @@
 /* @License 
  -------------------------------------------------------------------------------
- | osgAndroid - Copyright (C) 2012 Rafael Gait‡n, Mirage Technologies S.L.     |
+ | osgAndroid - Copyright (C) 2012 Rafael Gaitï¿½n, Mirage Technologies S.L.     |
  |                                                                             |
  | This library is free software; you can redistribute it and/or modify        |
  | it under the terms of the GNU Lesser General Public License as published    |
@@ -24,19 +24,23 @@ import javax.microedition.khronos.opengles.GL10;
 import android.opengl.GLSurfaceView;
 
 public class OSGRenderer implements GLSurfaceView.Renderer {
-	protected Viewer _viewer;
+	protected ViewerBase _viewer;
 
-	public OSGRenderer(Viewer viewer) {
+	public OSGRenderer(ViewerBase viewer) {
 		_viewer = viewer;
 	}
 	
 	public void onDrawFrame(GL10 gl) {
-		_viewer.frame();
+		if(_viewer.getNativePtr()!=0)
+			_viewer.frame();
 	}
 
 	public void onSurfaceChanged(GL10 gl, int width, int height) {
-		_viewer.setUpViewerAsEmbedded(0, 0, width, height);
-		_viewer.setViewport(0, 0, width, height);
+		if(_viewer.getNativePtr()!=0)
+		{
+			_viewer.setUpViewerAsEmbedded(0, 0, width, height);
+			_viewer.setViewport(0, 0, width, height);
+		}
 	}
 
 	public void onSurfaceCreated(GL10 gl, EGLConfig config) {

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/OffScreenViewer.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/OffScreenViewer.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.viewer;
 
 import javax.microedition.khronos.egl.EGL;

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/OffScreenViewer.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/OffScreenViewer.java
@@ -1,0 +1,474 @@
+package org.openscenegraph.osg.viewer;
+
+import javax.microedition.khronos.egl.EGL;
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGL11;
+import javax.microedition.khronos.egl.EGLSurface;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLDisplay;
+import javax.microedition.khronos.opengles.GL10;
+
+import org.openscenegraph.osg.Native;
+import org.openscenegraph.osg.core.Camera;
+import org.openscenegraph.osg.core.Image;
+import org.openscenegraph.osg.core.Matrix;
+import org.openscenegraph.osg.core.Node;
+import org.openscenegraph.osg.core.Vec2;
+import org.openscenegraph.osg.core.Vec3;
+import org.openscenegraph.osg.core.Vec2Array;
+import org.openscenegraph.osg.core.Vec3Array;
+import android.graphics.Bitmap;
+
+import android.opengl.GLSurfaceView;
+import android.util.Log;
+
+import java.nio.IntBuffer;
+
+public class OffScreenViewer implements Native {
+
+	private native long nativeCreatePBufferViewer();
+	private native void nativeSetUpViewerAsEmbedded(long cptr, int x, int y, int width, int height);
+	private native void nativeSetViewport(long cptr, int x, int y, int width, int height);
+	private native void nativeSetView(long cptr, int width, int height, float fov);
+	private native void nativeSetupCallback(long cptr);
+	private native long nativeGetFrame(long cptr, long matrix_ptr);
+	private native long nativeGetFrameImage(long cptr);
+	private native void nativeSetViewMatrix(long cptr, long matrix_ptr);
+	private native void nativeSetRenderMatrix(long cptr, long matrix_ptr);
+	private native void nativeDisposeViewer(long cptr);
+	private native void nativeSetSceneData(long cptr, long cptrNode);
+	private native void nativeFrame(long cptr);
+	private native long nativeGetCamera(long cptr);
+	private native long nativeRaycast(long viewer_cptr, long camera_ptr, long vec2array_cptr);
+
+
+	private EGLConfig eglConf = null;
+	private EGLSurface eglSurface = null;
+	private EGLContext eglCtx = null;
+	private EGLDisplay eglDisp = null;
+	private EGL10 mEGL = null;
+	private GL10 mGL = null;
+	private String mThreadOwner;
+	private GLSurfaceView.Renderer mRenderer = null;
+	
+	private int mWidth, mHeight;
+	private Bitmap mBitmap;
+
+	private long _cptr = 0;
+	private static String TAG = "org.openscenegraph.osg.viewer.OffScreenViewer";
+	private static final boolean DEBUG = false;
+	public long getNativePtr() {
+		return _cptr;
+	}
+
+	public OffScreenViewer(int width, int height, float fov) {
+		Log.w(TAG, "Creating OffScreenViewer ...");
+		_cptr = nativeCreatePBufferViewer();
+		mWidth = width; mHeight = height;
+		
+		int[] s_configAttribs2 = { EGL10.EGL_RED_SIZE, 
+									8, 
+									EGL10.EGL_GREEN_SIZE, 
+									8, 
+									EGL10.EGL_BLUE_SIZE, 
+									8, 
+									EGL10.EGL_ALPHA_SIZE, 
+									8, 
+									EGL10.EGL_SURFACE_TYPE,
+									EGL10.EGL_PBUFFER_BIT,
+									EGL10.EGL_NONE };
+		
+		int surfaceAttr[] = {
+				EGL10.EGL_WIDTH, width,
+				EGL10.EGL_HEIGHT, height,
+				EGL10.EGL_NONE
+		};
+		
+		int[] version = new int[2];
+		
+        // No error checking performed, minimum required code to elucidate logic
+        mEGL = (EGL10) EGLContext.getEGL();
+        eglDisp = mEGL.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
+        mEGL.eglInitialize(eglDisp, version);
+        ConfigChooserGLES11 selection = new ConfigChooserGLES11(8, 8, 8, 8, 16, 8);
+        selection.setAttributes(s_configAttribs2);
+        eglConf = selection.chooseConfig(mEGL, eglDisp);
+
+        //int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
+        //int[] ctxAttr = {
+        //        EGL_CONTEXT_CLIENT_VERSION, 2,
+        //        EGL10.EGL_NONE
+        //};
+        //int[] ctxAttr = {};
+        //eglCtx = mEGL.eglCreateContext(eglDisp, eglConf, EGL10.EGL_NO_CONTEXT, ctxAttr);
+        eglCtx = mEGL.eglCreateContext(eglDisp, eglConf, EGL10.EGL_NO_CONTEXT, null);
+
+        eglSurface = mEGL.eglCreatePbufferSurface(eglDisp, eglConf, surfaceAttr);
+        mEGL.eglMakeCurrent(eglDisp, eglSurface, eglSurface, eglCtx);
+
+        mGL = (GL10) eglCtx.getGL();
+
+        // Record thread owner of OpenGL context
+        mThreadOwner = Thread.currentThread().getName();
+        
+        
+        /*
+         * set up renderer
+         */
+        mRenderer = new OSGRenderer(asViewerBase());
+        // Does this thread own the OpenGL context?
+        if (!Thread.currentThread().getName().equals(mThreadOwner)) {
+            Log.e(TAG, "setRenderer: This thread does not own the OpenGL context.");
+            return;
+        }
+
+        // Call the renderer initialization routines
+        mRenderer.onSurfaceCreated(mGL, eglConf);
+        mRenderer.onSurfaceChanged(mGL, width, height);
+        //float fov = new Float(2.0*Math.atan(4.6032/(2.0*3.97)));
+        setView(width, height, fov);
+        nativeSetupCallback(_cptr);
+	}
+
+	public void close()
+	{
+		try {
+			//Log.w(TAG, "Closing OffScreen Renderer ...");
+			finalize();
+		} catch (Exception e) {
+			// TODO: handle exception
+			e.printStackTrace();
+		} catch (Throwable e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		//Log.w(TAG, "Finalizing OffScreen Renderer ...");
+		if(mEGL!=null)
+		{
+	        mEGL.eglMakeCurrent(eglDisp, eglSurface, eglSurface, eglCtx);
+	        /*
+			if(mRenderer!=null)
+			{
+				mRenderer.onDrawFrame(mGL);
+				mRenderer.onDrawFrame(mGL);
+			}
+			*/
+			dispose();
+			mRenderer = null;
+
+			mEGL.eglMakeCurrent(eglDisp, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_CONTEXT);
+	        mEGL.eglDestroySurface(eglDisp, eglSurface);
+	        eglSurface = null;
+	        mEGL.eglDestroyContext(eglDisp, eglCtx);
+	        eglCtx = null;
+	        mEGL.eglTerminate(eglDisp);
+	        mEGL = null;
+		}
+		//Log.w(TAG, "OffScreen Renderer destroyed ...");
+		super.finalize();
+	}
+
+	public void dispose() {
+		Log.w(TAG, "Disposing Off-Screen Viewer");
+		if (_cptr != 0)
+			nativeDisposeViewer(_cptr);
+		_cptr = 0;
+	}
+
+	public ViewerBase asViewerBase()
+	{
+		return new ViewerBase(_cptr);
+	}
+	
+	/**
+	 * Execute a frame
+	 * 
+	 */
+	public void frame() {
+		if (_cptr == 0)
+			return;
+		nativeFrame(_cptr);
+	}
+
+	/**
+	 * Set The viewport of the scene.
+	 * 
+	 * @param width
+	 *            viewport width.
+	 * @param height
+	 *            viewport height.
+	 */
+	public synchronized void setViewport(int x, int y, int width, int height) {
+		nativeSetViewport(_cptr, x, y, width, height);
+	}
+	
+	/**
+	 * Convenience method for setting up the viewer so it can be used embedded
+	 * in an external managed window.
+	 */
+	public void setUpViewerAsEmbedded(int x, int y, int width, int height) {
+		nativeSetUpViewerAsEmbedded(_cptr, x, y, width, height);
+	}
+
+	/**
+	 * Sets the scene to render
+	 * 
+	 */
+	public void setSceneData(Node node) {
+		nativeSetSceneData(_cptr, node.getNativePtr());
+	}
+
+	public void setViewMatrix(Matrix mat)
+	{
+		nativeSetViewMatrix(_cptr, mat.getNativePtr());
+	}
+	
+	public void setRenderMatrix(Matrix mat)
+	{
+		nativeSetRenderMatrix(_cptr, mat.getNativePtr());
+	}
+	
+	public void setView(int width, int height, float fov)
+	{
+		nativeSetView(_cptr, width, height, fov);
+	}
+
+	/**
+	 * Gets the viewer main camera
+	 * 
+	 * @return Camera
+	 */
+	public Camera getCamera() {
+		return new Camera(nativeGetCamera(_cptr));
+	}
+	
+	public Image getNextFrameImage(Matrix mat)
+	{
+		nativeSetViewMatrix(_cptr, mat.getNativePtr());
+		
+		if(mRenderer != null)
+		{
+			mRenderer.onDrawFrame(mGL);
+			mRenderer.onDrawFrame(mGL);
+		}
+		
+		convertToBitmap();
+		long image_ptr = nativeGetFrameImage(_cptr);
+		Image result = new Image();
+		if(image_ptr!=0)
+			result = new Image(image_ptr);
+		return result;
+	}
+	
+
+    private void convertToBitmap() {
+        int[] iat = new int[mWidth * mHeight];
+        IntBuffer ib = IntBuffer.allocate(mWidth * mHeight);
+        mGL.glReadPixels(0, 0, mWidth, mHeight, mGL.GL_RGBA, mGL.GL_UNSIGNED_BYTE, ib);
+        int[] ia = ib.array();
+
+        //Stupid !
+        // Convert upside down mirror-reversed image to right-side up normal
+        // image.
+        for (int i = 0; i < mHeight; i++) {
+            for (int j = 0; j < mWidth; j++) {
+                iat[(mHeight - i - 1) * mWidth + j] = ia[i * mWidth + j];
+            }
+        }
+        
+
+        mBitmap = Bitmap.createBitmap(mWidth, mHeight, Bitmap.Config.ARGB_8888);
+        mBitmap.copyPixelsFromBuffer(IntBuffer.wrap(iat));
+    }
+    
+    public Bitmap GetRenderImage()
+    {
+    	return mBitmap;
+    }
+    
+    public Vec3Array Raycast(Vec2Array image_points, Camera cam)
+    {
+    	return new Vec3Array(nativeRaycast(_cptr, cam.getNativePtr(), image_points.getNativePtr()));
+    }
+	
+	/**
+	 * Determine configuration
+	 */
+	private static class ConfigChooserGLES11 implements	GLSurfaceView.EGLConfigChooser {
+
+		public ConfigChooserGLES11(int r, int g, int b, int a, int depth, int stencil) {
+			mRedSize = r;
+			mGreenSize = g;
+			mBlueSize = b;
+			mAlphaSize = a;
+			mDepthSize = depth;
+			mStencilSize = stencil;
+		}
+		
+		/*
+		 * This EGL config specification is used to specify 2.0 rendering. We
+		 * use a minimum size of 4 bits for red/green/blue, but will perform
+		 * actual matching in chooseConfig() below.
+		 */
+		public int[] s_configAttribs2;
+		public void setAttributes(int[] attributes)
+		{
+			s_configAttribs2 = attributes;
+		}
+		
+		public EGLConfig chooseConfig(EGL10 egl, EGLDisplay display) {
+		
+			/*
+			 * Get the number of minimally matching EGL configurations
+			 */
+			int[] num_config = new int[1];
+			egl.eglChooseConfig(display, s_configAttribs2, null, 0, num_config);
+		
+			int numConfigs = num_config[0];
+		
+			if (numConfigs <= 0) {
+				throw new IllegalArgumentException(
+						"No configs match configSpec");
+			}
+		
+			/*
+			 * Allocate then read the array of minimally matching EGL configs
+			 */
+			EGLConfig[] configs = new EGLConfig[numConfigs];
+			egl.eglChooseConfig(display, s_configAttribs2, configs, numConfigs,
+					num_config);
+		
+			if (DEBUG) {
+				printConfigs(egl, display, configs);
+			}
+			/*
+			 * Now return the "best" one
+			 */
+			return chooseConfig(egl, display, configs);
+		}
+		
+		public EGLConfig chooseConfig(EGL10 egl, EGLDisplay display,
+				EGLConfig[] configs) {
+			for (EGLConfig config : configs) {
+				int sf = findConfigAttrib(egl, display, config, EGL10.EGL_SURFACE_TYPE, 0);
+				int d = findConfigAttrib(egl, display, config,
+						EGL10.EGL_DEPTH_SIZE, 0);
+				int s = findConfigAttrib(egl, display, config,
+						EGL10.EGL_STENCIL_SIZE, 0);
+		
+				// We need at least mDepthSize and mStencilSize bits
+				if (d < mDepthSize || s < mStencilSize)
+					continue;
+		
+				// We want an *exact* match for red/green/blue/alpha
+				int r = findConfigAttrib(egl, display, config,
+						EGL10.EGL_RED_SIZE, 0);
+				int g = findConfigAttrib(egl, display, config,
+						EGL10.EGL_GREEN_SIZE, 0);
+				int b = findConfigAttrib(egl, display, config,
+						EGL10.EGL_BLUE_SIZE, 0);
+				int a = findConfigAttrib(egl, display, config,
+						EGL10.EGL_ALPHA_SIZE, 0);
+		
+				if (r == mRedSize && g == mGreenSize && b == mBlueSize
+						&& a == mAlphaSize && ((sf & EGL10.EGL_PBUFFER_BIT) > 0) )
+					return config;
+			}
+			return null;
+		}
+		
+		private int findConfigAttrib(EGL10 egl, EGLDisplay display,
+				EGLConfig config, int attribute, int defaultValue) {
+		
+			if (egl.eglGetConfigAttrib(display, config, attribute, mValue)) {
+				return mValue[0];
+			}
+			return defaultValue;
+		}
+		
+		private void printConfigs(EGL10 egl, EGLDisplay display,
+				EGLConfig[] configs) {
+			int numConfigs = configs.length;
+			Log.w(TAG, String.format("%d configurations", numConfigs));
+			for (int i = 0; i < numConfigs; i++) {
+				Log.w(TAG, String.format("Configuration %d:\n", i));
+				printConfig(egl, display, configs[i]);
+			}
+		}
+		
+		private void printConfig(EGL10 egl, EGLDisplay display, EGLConfig config) {
+			int[] attributes = { EGL10.EGL_BUFFER_SIZE, EGL10.EGL_ALPHA_SIZE,
+					EGL10.EGL_BLUE_SIZE,
+					EGL10.EGL_GREEN_SIZE,
+					EGL10.EGL_RED_SIZE,
+					EGL10.EGL_DEPTH_SIZE,
+					EGL10.EGL_STENCIL_SIZE,
+					EGL10.EGL_CONFIG_CAVEAT,
+					EGL10.EGL_CONFIG_ID,
+					EGL10.EGL_LEVEL,
+					EGL10.EGL_MAX_PBUFFER_HEIGHT,
+					EGL10.EGL_MAX_PBUFFER_PIXELS,
+					EGL10.EGL_MAX_PBUFFER_WIDTH,
+					EGL10.EGL_NATIVE_RENDERABLE,
+					EGL10.EGL_NATIVE_VISUAL_ID,
+					EGL10.EGL_NATIVE_VISUAL_TYPE,
+					0x3030, // EGL10.EGL_PRESERVED_RESOURCES,
+					EGL10.EGL_SAMPLES,
+					EGL10.EGL_SAMPLE_BUFFERS,
+					EGL10.EGL_SURFACE_TYPE,
+					EGL10.EGL_TRANSPARENT_TYPE,
+					EGL10.EGL_TRANSPARENT_RED_VALUE,
+					EGL10.EGL_TRANSPARENT_GREEN_VALUE,
+					EGL10.EGL_TRANSPARENT_BLUE_VALUE,
+					0x3039, // EGL10.EGL_BIND_TO_TEXTURE_RGB,
+					0x303A, // EGL10.EGL_BIND_TO_TEXTURE_RGBA,
+					0x303B, // EGL10.EGL_MIN_SWAP_INTERVAL,
+					0x303C, // EGL10.EGL_MAX_SWAP_INTERVAL,
+					EGL10.EGL_LUMINANCE_SIZE, EGL10.EGL_ALPHA_MASK_SIZE,
+					EGL10.EGL_COLOR_BUFFER_TYPE, EGL10.EGL_RENDERABLE_TYPE,
+					0x3042 // EGL10.EGL_CONFORMANT
+			};
+			String[] names = { "EGL_BUFFER_SIZE", "EGL_ALPHA_SIZE",
+					"EGL_BLUE_SIZE", "EGL_GREEN_SIZE", "EGL_RED_SIZE",
+					"EGL_DEPTH_SIZE", "EGL_STENCIL_SIZE", "EGL_CONFIG_CAVEAT",
+					"EGL_CONFIG_ID", "EGL_LEVEL", "EGL_MAX_PBUFFER_HEIGHT",
+					"EGL_MAX_PBUFFER_PIXELS", "EGL_MAX_PBUFFER_WIDTH",
+					"EGL_NATIVE_RENDERABLE", "EGL_NATIVE_VISUAL_ID",
+					"EGL_NATIVE_VISUAL_TYPE", "EGL_PRESERVED_RESOURCES",
+					"EGL_SAMPLES", "EGL_SAMPLE_BUFFERS", "EGL_SURFACE_TYPE",
+					"EGL_TRANSPARENT_TYPE", "EGL_TRANSPARENT_RED_VALUE",
+					"EGL_TRANSPARENT_GREEN_VALUE",
+					"EGL_TRANSPARENT_BLUE_VALUE", "EGL_BIND_TO_TEXTURE_RGB",
+					"EGL_BIND_TO_TEXTURE_RGBA", "EGL_MIN_SWAP_INTERVAL",
+					"EGL_MAX_SWAP_INTERVAL", "EGL_LUMINANCE_SIZE",
+					"EGL_ALPHA_MASK_SIZE", "EGL_COLOR_BUFFER_TYPE",
+					"EGL_RENDERABLE_TYPE", "EGL_CONFORMANT" };
+			int[] value = new int[1];
+			for (int i = 0; i < attributes.length; i++) {
+				int attribute = attributes[i];
+				String name = names[i];
+				if (egl.eglGetConfigAttrib(display, config, attribute, value)) {
+					Log.w(TAG, String.format("  %s: %d\n", name, value[0]));
+				} else {
+					// Log.w(TAG, String.format("  %s: failed\n", name));
+					while (egl.eglGetError() != EGL10.EGL_SUCCESS)
+						;
+				}
+			}
+		}
+		
+		// Subclasses can adjust these values:
+		protected int mRedSize;
+		protected int mGreenSize;
+		protected int mBlueSize;
+		protected int mAlphaSize;
+		protected int mDepthSize;
+		protected int mStencilSize;
+		private int[] mValue = new int[1];
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/Viewer.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/Viewer.java
@@ -22,8 +22,10 @@ import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.egl.EGLDisplay;
 
+
 import org.openscenegraph.osg.Native;
 import org.openscenegraph.osg.core.Camera;
+import org.openscenegraph.osg.core.Matrix;
 import org.openscenegraph.osg.core.Node;
 import org.openscenegraph.osg.ga.GUIEventAdapter;
 
@@ -40,18 +42,27 @@ import android.view.View;
 public class Viewer extends GLSurfaceView implements Native,
 		View.OnTouchListener {
 
+	//EGLContext mContext;
+	//EGLSurface
 	private long _cptr;
 	private static String TAG = "org.openscenegraph.osg.viewer.Viewer";
 	private static final boolean DEBUG = false;
 	public long getNativePtr() {
 		return _cptr;
 	}
+	
 
 
 	/**
 	 * @return native pointer to the viewer
 	 */
 	private native long nativeCreateViewer();
+	
+	private native void nativeSetViewMatrix(long cptr, long matrix_ptr);
+
+	private native void nativeSetViewMatrixDistance(long cptr, long matrix_ptr, double distance);
+	
+	private native void nativeSetPerspectiveMatrix(long cptr, int width, int height, float fov);
 
 	private native void nativeDisposeViewer(long cptr);
 
@@ -96,6 +107,7 @@ public class Viewer extends GLSurfaceView implements Native,
 
 	public Viewer(Context context) {
 		super(context);
+		//Log.w(TAG, "Creating Viewer ...");
 		// init(false, 16, 8);
 		/* create the osg viewer */
 		_cptr = nativeCreateViewer();
@@ -109,17 +121,31 @@ public class Viewer extends GLSurfaceView implements Native,
 
 	@Override
 	protected void finalize() throws Throwable {
+		//Log.w(TAG, "Finalizing Viewer ...");
 		dispose();
 		super.finalize();
 	}
 
+	public ViewerBase asViewerBase()
+	{
+		return new ViewerBase(_cptr);
+	}
+	
 	public void dispose() {
-		Log.i(TAG, "Disposing viewer");
+		//Log.w(TAG, "Disposing viewer");
 		if (_cptr != 0)
 			nativeDisposeViewer(_cptr);
 		_cptr = 0;
 	}
 
+	/**
+	 * Convenience method for setting up the perspective with integrated camera
+	 */
+	public void setPerspectiveMatrix(int width, int height, float fovy)
+	{
+		nativeSetPerspectiveMatrix(_cptr, width, height, fovy);
+	}
+	
 	/**
 	 * Convenience method for setting up the viewer so it can be used embedded
 	 * in an external managed window.
@@ -239,7 +265,17 @@ public class Viewer extends GLSurfaceView implements Native,
 	public synchronized void home() {
 		native_home(_cptr);
 	}
+	
+	public synchronized void setViewMatrix(Matrix mat)
+	{
+		nativeSetViewMatrix(_cptr, mat.getNativePtr());
+	}
 
+	public synchronized void setView(Matrix mat, double distance)
+	{
+		nativeSetViewMatrixDistance(_cptr, mat.getNativePtr(),distance);
+	}
+	
 	/**
 	 * Gets the viewer main camera
 	 * 
@@ -306,7 +342,8 @@ public class Viewer extends GLSurfaceView implements Native,
 	}
 
 	public void init(boolean translucent, int depth, int stencil, int glesVersion) {
-		init(translucent, depth, stencil, new OSGRenderer(this), glesVersion);
+		//init(translucent, depth, stencil, new OSGRenderer(this), glesVersion);
+		init(translucent, depth, stencil, new OSGRenderer(asViewerBase()), glesVersion);
 	}
 	
 	public boolean performClick()

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/ViewerBase.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/ViewerBase.java
@@ -1,0 +1,55 @@
+package org.openscenegraph.osg.viewer;
+
+import org.openscenegraph.osg.core.Object;
+
+public class ViewerBase extends Object {
+
+	private native void nativeSetUpViewerAsEmbedded(long cptr, int x, int y, int width, int height);
+	private native void nativeSetViewport(long cptr, int x, int y, int width, int height);
+	private native void nativeFrame(long cptr);
+	
+	//protected long _cptr;
+	//public long getNativePtr() {
+	//	return _cptr;
+	//}
+	
+	public ViewerBase()
+	{
+		super();
+	}
+	
+	public ViewerBase(long cptr)
+	{
+		super(cptr);
+	}
+	
+	/**
+	 * Set The viewport of the scene.
+	 * 
+	 * @param width
+	 *            viewport width.
+	 * @param height
+	 *            viewport height.
+	 */
+	public synchronized void setViewport(int x, int y, int width, int height) {
+		nativeSetViewport(_cptr, x, y, width, height);
+	}
+	
+	/**
+	 * Convenience method for setting up the viewer so it can be used embedded
+	 * in an external managed window.
+	 */
+	public void setUpViewerAsEmbedded(int x, int y, int width, int height) {
+		nativeSetUpViewerAsEmbedded(_cptr, x, y, width, height);
+	}
+
+	/**
+	 * Execute a frame
+	 * 
+	 */
+	public void frame() {
+		if (_cptr == 0)
+			return;
+		nativeFrame(_cptr);
+	}
+}

--- a/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/ViewerBase.java
+++ b/org.openscenegraph.android/src/org/openscenegraph/osg/viewer/ViewerBase.java
@@ -1,3 +1,22 @@
+/* @License 
+ -------------------------------------------------------------------------------
+ | osgAndroid - Copyright (C) 2012 Rafael Gait�n, Mirage Technologies S.L.     |
+ | Contribution by Christian Kehl, Uni Research AS CIPR                        |
+ |                                                                             |
+ | This library is free software; you can redistribute it and/or modify        |
+ | it under the terms of the GNU Lesser General Public License as published    |
+ | by the Free Software Foundation; either version 3 of the License, or        |
+ | (at your option) any later version.                                         |
+ |                                                                             |
+ | This library is distributed in the hope that it will be useful, but         |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  |
+ | or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public     |
+ | License for more details.                                                   |
+ |                                                                             |
+ | You should have received a copy of the GNU Lesser General Public License    |
+ | along with this software; if not, write to the Free Software Foundation,    |
+ | Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.               |
+ ---------------------------------------------------------------------------- */
 package org.openscenegraph.osg.viewer;
 
 import org.openscenegraph.osg.core.Object;


### PR DESCRIPTION
Additions include:
- osg Image Writer 
- osg Node Reader/Writer 
- Off-Screen Rendering (using Pixel Buffer Objects) 
- wrapper for Vec2/Vec3/Vec4 Arrays; extended base function access
- extended wrapper for the Matrix 
- basic classes to construct a renderable object Mesh (Geode, Geometry, ...) 
- wrapped native functions for texture projection and Raycasting intersection

Additionally, I changed the Android.mk file to be able to compile the framework with the plugins. I can send a full manual of the compilation description, if needed (as pdf/tex). It would be good to see if the plugin inclusion also works for other users.
